### PR TITLE
feat: conectar GanttBoard a API real por proyecto

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import {
   Routes,
   Route,
+  Navigate,
+  useParams,
 } from "react-router-dom";
 import LoginForm from "./components/LoginForms.jsx";
 import PrivateRoute from "./components/PrivateRoute.jsx";
@@ -68,7 +70,8 @@ function App() {
 
           <Route path="/login" element={<LoginForm onLogin={handleLogin} />} />
           <Route path="/register" element={<RegisterForm />} />
-          <Route path="/gantt" element={<GanttBoard />} />
+          {/* Ruta /gantt suelta redirige a proyectos */}
+          <Route path="/gantt" element={<Navigate to="/mis-proyectos" replace />} />
           {token && (
             <>
               <Route path="/" element={<PrivateRoute token={token}><Dashboard token={token} /></PrivateRoute>} />
@@ -78,6 +81,14 @@ function App() {
               <Route path="/mis-proyectos" element={<PrivateRoute token={token}><ProjectsContainer token={token} /></PrivateRoute>} />
               <Route path="/crear-proyecto" element={<PrivateRoute token={token}><CreateProject token={token} /></PrivateRoute>} />
               <Route path="/editar-proyecto/:id" element={<PrivateRoute token={token}><EditProject token={token} /></PrivateRoute>} />
+              <Route
+                path="/mis-proyectos/:id/gantt"
+                element={
+                  <PrivateRoute token={token}>
+                    <GanttWrapper />
+                  </PrivateRoute>
+                }
+              />
               {user?.rol === "admin" && (
                 <Route path="/admin" element={<PrivateRoute token={token}><EditUsers /></PrivateRoute>} />
               )}
@@ -100,6 +111,12 @@ function App() {
       />
     </div>
   );
+}
+
+// Wrapper para extraer :id de la URL y pasarlo como prop a GanttBoard
+function GanttWrapper() {
+  const { id } = useParams();
+  return <GanttBoard proyectoId={id} />;
 }
 
 export default App;

--- a/src/components/GanttBoard.jsx
+++ b/src/components/GanttBoard.jsx
@@ -1,60 +1,80 @@
 // src/components/GanttBoard.jsx
-import React, { useRef, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Gantt } from "gantt-task-react";
 import "gantt-task-react/dist/index.css";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { buildAxios } from "@/api/axiosInstance";
 
-const GanttBoard = () => {
-  const today = new Date();
-  const tomorrow = new Date(today);
-  tomorrow.setDate(today.getDate() + 1);
+const GanttBoard = ({ proyectoId }) => {
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  const tasks = [
-    {
-      start: today,
-      end: tomorrow,
-      name: "Planificar tareas",
-      id: "Task1",
-      type: "task",
-      progress: 20,
-      isDisabled: false,
-      dependencies: []
-    },
-    {
-      start: new Date(tomorrow),
-      end: new Date(tomorrow.getTime() + 2 * 24 * 60 * 60 * 1000),
-      name: "Ejecutar proyecto",
-      id: "Task2",
-      type: "task",
-      progress: 50,
-      dependencies: ["Task1"]
-    },
-    {
-      start: new Date(tomorrow.getTime() + 3 * 24 * 60 * 60 * 1000),
-      end: new Date(tomorrow.getTime() + 5 * 24 * 60 * 60 * 1000),
-      name: "Revisión final",
-      id: "Task3",
-      type: "task",
-      progress: 0,
-      dependencies: ["Task2"]
+  useEffect(() => {
+    if (!proyectoId) {
+      setError("No se especificó un proyecto.");
+      setLoading(false);
+      return;
     }
-  ];
+
+    const token = localStorage.getItem("token");
+    const api = buildAxios(token);
+
+    api
+      .get(`/api/proyectos/${proyectoId}/mensajes`)
+      .then((res) => {
+        const mensajes = res.data;
+
+        const tareasValidas = mensajes
+          .filter((m) => m.start_date && m.expiration_date)
+          .map((m) => ({
+            id: String(m.id),
+            name: m.nombre,
+            start: new Date(m.start_date),
+            end: new Date(m.expiration_date),
+            type: "task",
+            progress: m.estado === "completado" ? 100 : m.estado === "en_progreso" ? 50 : 0,
+            isDisabled: false,
+            dependencies: [],
+          }));
+
+        if (tareasValidas.length === 0) {
+          setError("No hay mensajes con fechas asignadas para mostrar en el Gantt.");
+        } else {
+          setTasks(tareasValidas);
+        }
+      })
+      .catch(() => {
+        setError("Error al cargar los mensajes del proyecto.");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [proyectoId]);
 
   return (
     <div className="container mx-auto px-4 py-8">
       <Card>
         <CardHeader>
-          <CardTitle>Vista de Diagrama Gantt (Simulado)</CardTitle>
+          <CardTitle>Diagrama Gantt del Proyecto</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="overflow-auto">
-            <Gantt
-              tasks={tasks}
-              viewMode={"Day"}
-              listCellWidth={"155px"}
-              columnWidth={65}
-            />
-          </div>
+          {loading && (
+            <p className="text-sm text-gray-500">Cargando tareas...</p>
+          )}
+          {!loading && error && (
+            <p className="text-sm text-red-500">{error}</p>
+          )}
+          {!loading && !error && tasks.length > 0 && (
+            <div className="overflow-auto">
+              <Gantt
+                tasks={tasks}
+                viewMode={"Day"}
+                listCellWidth={"155px"}
+                columnWidth={65}
+              />
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { PencilIcon, TrashIcon, CalendarIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/outline';
+import { PencilIcon, TrashIcon, CalendarIcon, ChatBubbleLeftIcon, ChartBarIcon } from '@heroicons/react/24/outline';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -94,9 +94,27 @@ const ProjectCard = ({ proyecto, onDelete, onEdit }) => {
         <Badge variant="secondary" className="text-xs">
           {proyecto.estado || 'Activo'}
         </Badge>
-        <Button variant="ghost" size="sm" className="text-blue-500 hover:text-blue-600">
-          Ver mensajes
-        </Button>
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-blue-500 hover:text-blue-600"
+          >
+            Ver mensajes
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-emerald-600 hover:text-emerald-700 flex items-center gap-1"
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/mis-proyectos/${proyecto.id}/gantt`);
+            }}
+          >
+            <ChartBarIcon className="h-4 w-4" />
+            Gantt
+          </Button>
+        </div>
       </CardFooter>
     </Card>
   );


### PR DESCRIPTION
## Cambios

### `GanttBoard.jsx` (Issue #1)
- ✅ Recibe `proyectoId` como prop
- ✅ Fetch real a `/api/proyectos/:id/mensajes`
- ✅ Transforma mensajes al formato `gantt-task-react` (start, end, name, id, progress)
- ✅ Progress automático según estado: completado=100%, en_progreso=50%, pendiente=0%
- ✅ Loading state y manejo de errores
- ✅ Filtra mensajes sin fechas con mensaje informativo

### `App.jsx` (Issue #2)
- ✅ Ruta `/mis-proyectos/:id/gantt` con `PrivateRoute`
- ✅ `GanttWrapper` extrae `:id` de URL y lo pasa como prop a `GanttBoard`
- ✅ Ruta `/gantt` suelta redirige a `/mis-proyectos`

### `ProjectCard.jsx` (Issue #3)
- ✅ Botón "Gantt" con `ChartBarIcon` navega a `/mis-proyectos/:id/gantt`
- ✅ Estilo consistente con Tailwind (emerald, ghost)
- ✅ `e.stopPropagation()` evita conflicto con el click de la card

Closes #1, #2, #3