### PR TITLE
feat: frontend completo de Workspaces

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,9 @@ import CreateProject from './components/CreateProject';
 import EditProject from './components/EditProject';
 import './styles/datepicker.css';
 import GanttBoard from './components/GanttBoard';
+import WorkspacesContainer from './components/containers/WorkspacesContainer';
+import CreateWorkspace from './components/CreateWorkspace';
+import EditWorkspace from './components/EditWorkspace';
 
 function App() {
   const [token, setToken] = useState(localStorage.getItem("token") || null);
@@ -81,6 +84,9 @@ function App() {
               <Route path="/mis-proyectos" element={<PrivateRoute token={token}><ProjectsContainer token={token} /></PrivateRoute>} />
               <Route path="/crear-proyecto" element={<PrivateRoute token={token}><CreateProject token={token} /></PrivateRoute>} />
               <Route path="/editar-proyecto/:id" element={<PrivateRoute token={token}><EditProject token={token} /></PrivateRoute>} />
+              <Route path="/mis-workspaces" element={<PrivateRoute token={token}><WorkspacesContainer token={token} /></PrivateRoute>} />
+              <Route path="/crear-workspace" element={<PrivateRoute token={token}><CreateWorkspace token={token} /></PrivateRoute>} />
+              <Route path="/editar-workspace/:id" element={<PrivateRoute token={token}><EditWorkspace token={token} /></PrivateRoute>} />
               <Route
                 path="/mis-proyectos/:id/gantt"
                 element={

--- a/src/components/CreateWorkspace.jsx
+++ b/src/components/CreateWorkspace.jsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useWorkspaceQuery } from '../hooks/useWorkspaceQuery';
+
+const CreateWorkspace = ({ token }) => {
+  const navigate = useNavigate();
+  const { crearWorkspace } = useWorkspaceQuery(token);
+  const [formData, setFormData] = useState({
+    nombre: '',
+    descripcion: '',
+    is_shared: false,
+  });
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await crearWorkspace.mutateAsync(formData);
+      navigate('/mis-workspaces');
+    } catch (error) {
+      console.error('Error al crear el workspace:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-800 mb-8">Crear Nuevo Workspace</h1>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div>
+            <label htmlFor="nombre" className="block text-sm font-medium text-gray-700 mb-1">
+              Nombre del Workspace
+            </label>
+            <input
+              type="text"
+              id="nombre"
+              name="nombre"
+              value={formData.nombre}
+              onChange={handleChange}
+              required
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder="Ej: Desarrollo Frontend"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="descripcion" className="block text-sm font-medium text-gray-700 mb-1">
+              Descripción
+            </label>
+            <textarea
+              id="descripcion"
+              name="descripcion"
+              value={formData.descripcion}
+              onChange={handleChange}
+              rows="4"
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder="Describe el propósito de este workspace"
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              id="is_shared"
+              name="is_shared"
+              checked={formData.is_shared}
+              onChange={handleChange}
+              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+            />
+            <label htmlFor="is_shared" className="text-sm font-medium text-gray-700">
+              Compartir con otros usuarios
+            </label>
+          </div>
+
+          <div className="flex justify-end space-x-4">
+            <button
+              type="button"
+              onClick={() => navigate('/mis-workspaces')}
+              className="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors duration-200"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-4 py-2 text-white bg-indigo-600 rounded-md hover:bg-indigo-700 transition-colors duration-200 disabled:opacity-50"
+            >
+              {loading ? 'Creando...' : 'Crear Workspace'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default CreateWorkspace;

--- a/src/components/EditWorkspace.jsx
+++ b/src/components/EditWorkspace.jsx
@@ -1,0 +1,141 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useWorkspaceQuery } from '../hooks/useWorkspaceQuery';
+
+const EditWorkspace = ({ token }) => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const { workspaces, actualizarWorkspace } = useWorkspaceQuery(token);
+  const [formData, setFormData] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const ws = workspaces.find((w) => String(w.id) === String(id));
+    if (ws) {
+      setFormData({
+        nombre: ws.nombre || '',
+        descripcion: ws.descripcion || '',
+        is_shared: ws.is_shared || false,
+        estado: ws.estado || 'activo',
+      });
+    }
+  }, [workspaces, id]);
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await actualizarWorkspace.mutateAsync({ id: Number(id), ...formData });
+      navigate('/mis-workspaces');
+    } catch (error) {
+      console.error('Error al actualizar el workspace:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!formData) {
+    return (
+      <div className="container mx-auto px-4 py-8 text-gray-500">
+        Cargando workspace...
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-800 mb-8">Editar Workspace</h1>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div>
+            <label htmlFor="nombre" className="block text-sm font-medium text-gray-700 mb-1">
+              Nombre del Workspace
+            </label>
+            <input
+              type="text"
+              id="nombre"
+              name="nombre"
+              value={formData.nombre}
+              onChange={handleChange}
+              required
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="descripcion" className="block text-sm font-medium text-gray-700 mb-1">
+              Descripción
+            </label>
+            <textarea
+              id="descripcion"
+              name="descripcion"
+              value={formData.descripcion}
+              onChange={handleChange}
+              rows="4"
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="estado" className="block text-sm font-medium text-gray-700 mb-1">
+              Estado
+            </label>
+            <select
+              id="estado"
+              name="estado"
+              value={formData.estado}
+              onChange={handleChange}
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            >
+              <option value="activo">Activo</option>
+              <option value="inactivo">Inactivo</option>
+              <option value="archivado">Archivado</option>
+            </select>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              id="is_shared"
+              name="is_shared"
+              checked={formData.is_shared}
+              onChange={handleChange}
+              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+            />
+            <label htmlFor="is_shared" className="text-sm font-medium text-gray-700">
+              Compartir con otros usuarios
+            </label>
+          </div>
+
+          <div className="flex justify-end space-x-4">
+            <button
+              type="button"
+              onClick={() => navigate('/mis-workspaces')}
+              className="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors duration-200"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="px-4 py-2 text-white bg-indigo-600 rounded-md hover:bg-indigo-700 transition-colors duration-200 disabled:opacity-50"
+            >
+              {loading ? 'Guardando...' : 'Guardar cambios'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default EditWorkspace;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { HomeIcon, ChatBubbleLeftIcon, ArrowRightOnRectangleIcon, UserGroupIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline/index.js';
+import { HomeIcon, ChatBubbleLeftIcon, ArrowRightOnRectangleIcon, UserGroupIcon, ClipboardDocumentIcon, RectangleGroupIcon } from '@heroicons/react/24/outline/index.js';
 
 const Navbar = ({ token, onLogout }) => {
   const navigate = useNavigate();
@@ -33,6 +33,13 @@ const Navbar = ({ token, onLogout }) => {
                 >
                   <ClipboardDocumentIcon className="h-6 w-6 mr-2" />
                   <span className="font-semibold">Mis Proyectos</span>
+                </Link>
+                <Link
+                  to="/mis-workspaces"
+                  className="flex items-center text-gray-800 hover:text-indigo-600 transition-colors duration-200"
+                >
+                  <RectangleGroupIcon className="h-6 w-6 mr-2" />
+                  <span className="font-semibold">Workspaces</span>
                 </Link>
 
                 {user.rol === 'admin' && (

--- a/src/components/WorkspaceCard.jsx
+++ b/src/components/WorkspaceCard.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { PencilIcon, TrashIcon, ShareIcon, LockClosedIcon } from '@heroicons/react/24/outline';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import Swal from 'sweetalert2';
+
+const WorkspaceCard = ({ workspace, onDelete, onEdit, isOwner }) => {
+  const navigate = useNavigate();
+
+  const handleDelete = (e) => {
+    e.stopPropagation();
+    Swal.fire({
+      title: '¿Estás seguro?',
+      text: 'No podrás revertir esta acción',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#3085d6',
+      cancelButtonColor: '#d33',
+      confirmButtonText: 'Sí, eliminar',
+      cancelButtonText: 'Cancelar',
+    }).then((result) => {
+      if (result.isConfirmed) {
+        onDelete(workspace.id);
+        Swal.fire('¡Eliminado!', 'El workspace ha sido eliminado.', 'success');
+      }
+    });
+  };
+
+  const handleEdit = (e) => {
+    e.stopPropagation();
+    onEdit(workspace);
+  };
+
+  const estadoColor = {
+    activo: 'bg-green-100 text-green-700',
+    inactivo: 'bg-gray-100 text-gray-500',
+    archivado: 'bg-yellow-100 text-yellow-700',
+  };
+
+  return (
+    <Card className="group hover:shadow-lg transition-all duration-300">
+      <CardHeader className="space-y-1">
+        <div className="flex items-start justify-between">
+          <CardTitle className="text-xl font-semibold tracking-tight">
+            {workspace.nombre}
+          </CardTitle>
+          {isOwner && (
+            <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={handleEdit}
+                className="h-8 w-8"
+              >
+                <PencilIcon className="h-4 w-4 text-blue-500" />
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={handleDelete}
+                className="h-8 w-8"
+              >
+                <TrashIcon className="h-4 w-4 text-red-500" />
+              </Button>
+            </div>
+          )}
+        </div>
+        <CardDescription className="text-sm text-gray-500 line-clamp-2">
+          {workspace.descripcion || 'Sin descripción.'}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            {workspace.is_shared ? (
+              <>
+                <ShareIcon className="h-4 w-4 text-blue-400" />
+                <span>Compartido</span>
+              </>
+            ) : (
+              <>
+                <LockClosedIcon className="h-4 w-4 text-gray-400" />
+                <span>Privado</span>
+              </>
+            )}
+          </div>
+          {workspace.created_at && (
+            <div className="text-sm text-gray-400">
+              Creado el{' '}
+              {format(new Date(workspace.created_at), "d 'de' MMMM 'de' yyyy", { locale: es })}
+            </div>
+          )}
+        </div>
+      </CardContent>
+
+      <CardFooter className="flex justify-between items-center pt-4">
+        <Badge
+          className={`text-xs ${estadoColor[workspace.estado] || estadoColor.activo}`}
+          variant="outline"
+        >
+          {workspace.estado || 'activo'}
+        </Badge>
+        {!isOwner && (
+          <span className="text-xs text-blue-400 font-medium">Compartido contigo</span>
+        )}
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default WorkspaceCard;

--- a/src/components/containers/WorkspacesContainer.jsx
+++ b/src/components/containers/WorkspacesContainer.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useWorkspaceQuery } from '../../hooks/useWorkspaceQuery';
+import { toast } from 'react-toastify';
+import WorkspacesView from '../views/WorkspacesView';
+import { jwtDecode } from 'jwt-decode';
+
+const WorkspacesContainer = ({ token }) => {
+  const navigate = useNavigate();
+  const { workspaces, isLoading, error, eliminarWorkspace } = useWorkspaceQuery(token);
+
+  const currentUserId = (() => {
+    try {
+      return jwtDecode(token)?.sub;
+    } catch {
+      return null;
+    }
+  })();
+
+  useEffect(() => {
+    if (error) {
+      toast.error('Error al cargar los workspaces');
+    }
+  }, [error]);
+
+  const handleDelete = async (id) => {
+    try {
+      await eliminarWorkspace.mutateAsync(id);
+    } catch (error) {
+      console.error('Error al eliminar el workspace:', error);
+    }
+  };
+
+  const handleEdit = (workspace) => {
+    navigate(`/editar-workspace/${workspace.id}`);
+  };
+
+  const handleCreateClick = () => {
+    navigate('/crear-workspace');
+  };
+
+  const handleRetry = () => {
+    window.location.reload();
+  };
+
+  return (
+    <WorkspacesView
+      workspaces={workspaces}
+      isLoading={isLoading}
+      error={error}
+      onDelete={handleDelete}
+      onEdit={handleEdit}
+      onCreateClick={handleCreateClick}
+      onRetry={handleRetry}
+      currentUserId={currentUserId}
+    />
+  );
+};
+
+export default WorkspacesContainer;

--- a/src/components/views/WorkspacesView.jsx
+++ b/src/components/views/WorkspacesView.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { PlusIcon, RectangleGroupIcon } from '@heroicons/react/24/outline';
+import WorkspaceCard from '../WorkspaceCard';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const WorkspacesView = ({
+  workspaces = [],
+  isLoading,
+  error,
+  onDelete,
+  onEdit,
+  onCreateClick,
+  onRetry,
+  currentUserId,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex justify-between items-center mb-8">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-10 w-36" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <Card key={i} className="overflow-hidden">
+              <CardHeader>
+                <Skeleton className="h-6 w-3/4" />
+                <Skeleton className="h-4 w-1/2 mt-2" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-4 w-full mt-2" />
+                <Skeleton className="h-4 w-2/3 mt-2" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Card className="max-w-md mx-auto">
+          <CardHeader>
+            <CardTitle className="text-red-500">Error al cargar los workspaces</CardTitle>
+            <CardDescription>Ha ocurrido un error al intentar cargar tus workspaces.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={onRetry} className="w-full">
+              Reintentar
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-800">Mis Workspaces</h1>
+          <p className="text-gray-500 mt-1">Organiza y comparte tus espacios de trabajo</p>
+        </div>
+        <Button onClick={onCreateClick} className="flex items-center gap-2">
+          <PlusIcon className="h-5 w-5" />
+          Crear Workspace
+        </Button>
+      </div>
+
+      {workspaces.length === 0 ? (
+        <Card className="text-center p-8">
+          <CardContent className="flex flex-col items-center justify-center py-12">
+            <div className="rounded-full bg-indigo-100 p-3 mb-4">
+              <RectangleGroupIcon className="h-8 w-8 text-indigo-500" />
+            </div>
+            <h3 className="text-xl font-semibold text-gray-800 mb-2">No tienes workspaces creados</h3>
+            <p className="text-gray-500 mb-6">Crea tu primer workspace para organizar tu trabajo</p>
+            <Button onClick={onCreateClick} size="lg">
+              Crear mi primer workspace
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {workspaces.map((ws) => (
+            <WorkspaceCard
+              key={ws.id}
+              workspace={ws}
+              onDelete={onDelete}
+              onEdit={onEdit}
+              isOwner={String(ws.owner_id) === String(currentUserId)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WorkspacesView;

--- a/src/hooks/useWorkspaceQuery.js
+++ b/src/hooks/useWorkspaceQuery.js
@@ -1,0 +1,76 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import { buildAxios } from '../api/axiosInstance';
+
+export const useWorkspaceQuery = (token) => {
+  const axios = buildAxios(token);
+  const qc = useQueryClient();
+
+  const { data: workspaces = [], isLoading, error } = useQuery({
+    queryKey: ['workspaces'],
+    queryFn: async () => {
+      try {
+        const response = await axios.get('/api/workspaces/');
+        return response.data || [];
+      } catch (error) {
+        console.error('Error al cargar workspaces:', error);
+        toast.error('Error al cargar los workspaces');
+        return [];
+      }
+    },
+    enabled: !!token,
+    retry: 1,
+    staleTime: 30000,
+    cacheTime: 60000,
+  });
+
+  const crearWorkspace = useMutation({
+    mutationFn: async (datos) => {
+      const response = await axios.post('/api/workspaces/', datos);
+      return response.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries(['workspaces']);
+      toast.success('Workspace creado correctamente');
+    },
+    onError: () => {
+      toast.error('Error al crear el workspace');
+    },
+  });
+
+  const actualizarWorkspace = useMutation({
+    mutationFn: async ({ id, ...datos }) => {
+      const response = await axios.put(`/api/workspaces/${id}`, datos);
+      return response.data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries(['workspaces']);
+      toast.success('Workspace actualizado correctamente');
+    },
+    onError: () => {
+      toast.error('Error al actualizar el workspace');
+    },
+  });
+
+  const eliminarWorkspace = useMutation({
+    mutationFn: async (id) => {
+      await axios.delete(`/api/workspaces/${id}`);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries(['workspaces']);
+      toast.success('Workspace eliminado correctamente');
+    },
+    onError: () => {
+      toast.error('Error al eliminar el workspace');
+    },
+  });
+
+  return {
+    workspaces,
+    isLoading,
+    error,
+    crearWorkspace,
+    actualizarWorkspace,
+    eliminarWorkspace,
+  };
+};


### PR DESCRIPTION
## Archivos nuevos

- `useWorkspaceQuery.js` — hook con CRUD completo usando React Query
- `WorkspaceCard.jsx` — card con ícono compartido/privado, acciones solo para el dueño
- `WorkspacesView.jsx` — grid con skeleton loading, empty state, manejo de errores
- `WorkspacesContainer.jsx` — lógica de navegación y CRUD
- `CreateWorkspace.jsx` — formulario: nombre, descripción, toggle compartir
- `EditWorkspace.jsx` — formulario edición con selector de estado (activo/inactivo/archivado)

## Archivos modificados

- `Navbar.jsx` — link a `/mis-workspaces` con `RectangleGroupIcon`
- `App.jsx` — rutas `/mis-workspaces`, `/crear-workspace`, `/editar-workspace/:id` con `PrivateRoute`