### PR TITLE
feat: arquitectura capa móvil y desktop (Sprint 1)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,126 @@
+name: Build Android
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'src-tauri/**'
+      - 'package.json'
+      - 'package-lock.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'src-tauri/**'
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Build release APK (signed)'
+        required: false
+        default: 'false'
+
+jobs:
+  build-android:
+    name: Build Android APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      # ── Checkout ──────────────────────────────────────────────────
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ── JDK 17 ────────────────────────────────────────────────────
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # ── Android SDK ───────────────────────────────────────────────
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android NDK & Build Tools
+        run: |
+          sdkmanager "ndk;27.0.12077973" \
+                     "build-tools;34.0.0" \
+                     "platforms;android-34"
+
+      # ── Rust ──────────────────────────────────────────────────────
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: 'src-tauri -> target'
+
+      - name: Add Android Rust targets
+        run: |
+          rustup target add \
+            aarch64-linux-android \
+            armv7-linux-androideabi \
+            x86_64-linux-android \
+            i686-linux-android
+
+      # ── Node / npm ────────────────────────────────────────────────
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ── Build frontend ────────────────────────────────────────────
+      - name: Build frontend
+        run: npm run build
+
+      # ── Tauri Android (debug) ─────────────────────────────────────
+      - name: Build Android APK (debug)
+        if: github.event.inputs.release != 'true'
+        run: npm run tauri:build:android -- --apk
+        env:
+          NDK_HOME: ${{ env.ANDROID_NDK_ROOT }}
+
+      # ── Tauri Android (release, firmado) ──────────────────────────
+      - name: Setup keystore
+        if: github.event.inputs.release == 'true'
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > docktask.keystore
+        
+      - name: Build Android APK (release, signed)
+        if: github.event.inputs.release == 'true'
+        run: npm run tauri:build:android -- --apk
+        env:
+          NDK_HOME: ${{ env.ANDROID_NDK_ROOT }}
+          TAURI_ANDROID_SIGNING_KEY: docktask.keystore
+          TAURI_ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          TAURI_ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          TAURI_ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+
+      # ── Subir APK como artifact ───────────────────────────────────
+      - name: Find APK
+        id: find-apk
+        run: |
+          APK=$(find src-tauri/gen/android -name "*.apk" | head -1)
+          echo "apk_path=$APK" >> $GITHUB_OUTPUT
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: docktask-android-${{ github.sha }}
+          path: ${{ steps.find-apk.outputs.apk_path }}
+          retention-days: 14
+
+      # ── Resumen ───────────────────────────────────────────────────
+      - name: Summary
+        run: |
+          echo "### ✅ Build Android completado" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **APK:** \`${{ steps.find-apk.outputs.apk_path }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Modo:** ${{ github.event.inputs.release == 'true' && 'Release (firmado)' || 'Debug' }}" >> $GITHUB_STEP_SUMMARY

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query": "^5.75.5",
     "@tanstack/react-query-devtools": "^5.75.5",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-deep-link": "^2",
     "@tauri-apps/plugin-notification": "^2",
     "@tauri-apps/plugin-os": "^2",
     "@tauri-apps/plugin-store": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "frontend-contacto-vite",
+  "name": "docktask",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -11,9 +11,7 @@
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
-    "tauri:build:ios": "tauri ios build",
     "tauri:build:android": "tauri android build",
-    "tauri:dev:ios": "tauri ios dev",
     "tauri:dev:android": "tauri android dev"
   },
   "dependencies": {
@@ -26,6 +24,9 @@
     "@tanstack/react-query": "^5.75.5",
     "@tanstack/react-query-devtools": "^5.75.5",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-notification": "^2",
+    "@tauri-apps/plugin-os": "^2",
+    "@tauri-apps/plugin-store": "^2",
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,8 @@ tauri-plugin-sql   = { version = "2", features = ["sqlite"] }
 tauri-plugin-store = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-http  = "2"
-tauri-plugin-os    = "2"
+tauri-plugin-os        = "2"
+tauri-plugin-deep-link = "2"
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
 tokio       = { version = "1", features = ["full"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,6 +23,8 @@
     "http:default",
     "http:allow-fetch",
     "os:default",
-    "os:allow-platform"
+    "os:allow-platform",
+    "deep-link:default",
+    "deep-link:allow-get-current"
   ]
 }

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "../gen/schemas/desktop-schema.json",
-  "identifier": "default",
-  "description": "DockTask — permisos desktop (Linux, Windows, macOS)",
-  "platforms": ["linux", "windows", "macos"],
+  "$schema": "../gen/schemas/mobile-schema.json",
+  "identifier": "mobile",
+  "description": "DockTask — permisos Android",
+  "platforms": ["android"],
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -23,6 +23,8 @@
     "http:default",
     "http:allow-fetch",
     "os:default",
-    "os:allow-platform"
+    "os:allow-platform",
+    "deep-link:default",
+    "deep-link:allow-get-current"
   ]
 }

--- a/src-tauri/src/commands/notifications.rs
+++ b/src-tauri/src/commands/notifications.rs
@@ -3,6 +3,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
 
 // ─────────────────────────────────────────────
 //  MODELOS
@@ -38,7 +39,7 @@ pub struct PendingNotification {
 // ─────────────────────────────────────────────
 
 /// Programa un recordatorio para una tarea.
-/// El frontend llama: invoke("schedule_task_reminder", { reminder: { ... } })
+/// Persiste en SQLite — el sync worker lo dispara cuando llega la hora.
 ///
 /// Ejemplo de uso desde JS:
 /// ```js
@@ -54,7 +55,10 @@ pub struct PendingNotification {
 /// });
 /// ```
 #[tauri::command]
-pub async fn schedule_task_reminder(reminder: ReminderRequest) -> Result<String, String> {
+pub async fn schedule_task_reminder(
+    app: AppHandle,
+    reminder: ReminderRequest,
+) -> Result<String, String> {
     // Validar que fire_at sea una fecha futura
     let fire_at = reminder
         .fire_at
@@ -65,42 +69,123 @@ pub async fn schedule_task_reminder(reminder: ReminderRequest) -> Result<String,
         return Err("La fecha de disparo debe ser en el futuro".to_string());
     }
 
-    log::info!(
-        "Recordatorio programado: id={} task_id={} fire_at={}",
-        reminder.id,
-        reminder.task_id,
-        reminder.fire_at
-    );
+    let db_path = get_db_path(&app)?;
+    let reminder_id = reminder.id.clone();
+    let created_at = Utc::now().to_rfc3339();
 
-    // TODO: Insertar en pending_notifications (SQLite)
-    // La notificación será disparada por el NotificationWorker (sync/worker.rs)
+    // Persistir en SQLite
+    tokio::task::spawn_blocking(move || {
+        let conn = rusqlite::Connection::open(&db_path)
+            .map_err(|e| format!("SQLite open: {}", e))?;
 
-    Ok(reminder.id)
+        conn.execute(
+            "INSERT OR REPLACE INTO pending_notifications
+             (id, task_id, title, body, fire_at, fired, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6)",
+            rusqlite::params![
+                reminder.id,
+                reminder.task_id,
+                reminder.title,
+                reminder.body,
+                reminder.fire_at,
+                created_at,
+            ],
+        )
+        .map_err(|e| format!("SQLite insert: {}", e))?;
+
+        log::info!(
+            "📅 Recordatorio guardado: id={} fire_at={}",
+            reminder.id,
+            reminder.fire_at
+        );
+        Ok::<_, String>(())
+    })
+    .await
+    .map_err(|e| format!("Spawn error: {}", e))??;
+
+    Ok(reminder_id)
 }
 
 /// Cancela un recordatorio programado por su ID
 #[tauri::command]
-pub async fn cancel_reminder(reminder_id: String) -> Result<(), String> {
-    log::info!("Cancelar recordatorio: id={}", reminder_id);
-    // TODO: Marcar como cancelado en SQLite (fired=-1)
+pub async fn cancel_reminder(app: AppHandle, reminder_id: String) -> Result<(), String> {
+    let db_path = get_db_path(&app)?;
+
+    tokio::task::spawn_blocking(move || {
+        let conn = rusqlite::Connection::open(&db_path)
+            .map_err(|e| format!("SQLite open: {}", e))?;
+
+        conn.execute(
+            "UPDATE pending_notifications SET fired = -1 WHERE id = ?1",
+            [&reminder_id],
+        )
+        .map_err(|e| format!("SQLite update: {}", e))?;
+
+        log::info!("🗑️ Recordatorio cancelado: id={}", reminder_id);
+        Ok::<_, String>(())
+    })
+    .await
+    .map_err(|e| format!("Spawn error: {}", e))??;
+
     Ok(())
 }
 
-/// Lista las notificaciones pendientes (no disparadas)
+/// Lista las notificaciones pendientes (no disparadas ni canceladas)
 #[tauri::command]
-pub async fn get_pending_notifications() -> Result<Vec<PendingNotification>, String> {
-    // TODO: Leer desde SQLite pending_notifications WHERE fired=0 AND fire_at > now()
-    Ok(vec![])
+pub async fn get_pending_notifications(
+    app: AppHandle,
+) -> Result<Vec<PendingNotification>, String> {
+    let db_path = get_db_path(&app)?;
+
+    if !db_path.exists() {
+        return Ok(vec![]);
+    }
+
+    let now_str = Utc::now().to_rfc3339();
+
+    let notifs = tokio::task::spawn_blocking(move || {
+        let conn = rusqlite::Connection::open(&db_path)
+            .map_err(|e| format!("SQLite open: {}", e))?;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, task_id, title, body, fire_at
+                 FROM pending_notifications
+                 WHERE fired = 0 AND fire_at > ?1
+                 ORDER BY fire_at ASC",
+            )
+            .map_err(|e| e.to_string())?;
+
+        let result: Vec<PendingNotification> = stmt
+            .query_map([&now_str], |row| {
+                Ok(PendingNotification {
+                    id: row.get(0)?,
+                    task_id: row.get(1)?,
+                    title: row.get(2)?,
+                    body: row.get(3)?,
+                    fire_at: row.get(4)?,
+                })
+            })
+            .map_err(|e| e.to_string())?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok::<_, String>(result)
+    })
+    .await
+    .map_err(|e| format!("Spawn error: {}", e))??;
+
+    Ok(notifs)
 }
 
 // ─────────────────────────────────────────────
 //  HELPERS (uso interno desde el worker)
 // ─────────────────────────────────────────────
 
-/// Envía una notificación nativa inmediata al OS
+/// Envía una notificación nativa inmediata al OS/Android
 /// Llamado desde el sync worker cuando llega la hora
 pub fn fire_native_notification(
-    app: &tauri::AppHandle,
+    app: &AppHandle,
     title: &str,
     body: &str,
 ) -> Result<(), String> {
@@ -113,6 +198,15 @@ pub fn fire_native_notification(
         .show()
         .map_err(|e| format!("Error al enviar notificación: {}", e))?;
 
-    log::info!("Notificación enviada: title={}", title);
+    log::info!("🔔 Notificación enviada: title={}", title);
     Ok(())
+}
+
+fn get_db_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("No se pudo obtener app_data_dir: {}", e))?;
+
+    Ok(data_dir.join("docktask.db"))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_os::init())
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(
             tauri_plugin_sql::Builder::default()
                 .add_migrations("sqlite:docktask.db", commands::offline::db_migrations())
@@ -35,7 +36,7 @@ pub fn run() {
             // Info del sistema
             commands::system::get_network_status,
         ])
-        // ── Setup: iniciar sync worker en background ──────────────────────
+        // ── Setup: sync worker + deep link handler ────────────────────────
         .setup(|app| {
             let app_handle = app.handle().clone();
 
@@ -43,6 +44,18 @@ pub fn run() {
             tauri::async_runtime::spawn(async move {
                 sync::worker::start_sync_loop(app_handle).await;
             });
+
+            // Manejar deep links — reenviar URL a React para que el router la procese
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "windows", target_os = "macos"))]
+            {
+                let app_handle = app.handle().clone();
+                app.listen("deep-link://new-url", move |event| {
+                    if let Some(url) = event.payload().strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+                        log::info!("🔗 Deep link recibido: {}", url);
+                        let _ = app_handle.emit("deeplink:navigate", url.to_string());
+                    }
+                });
+            }
 
             Ok(())
         })

--- a/src-tauri/src/sync/worker.rs
+++ b/src-tauri/src/sync/worker.rs
@@ -16,7 +16,7 @@ const SYNC_INTERVAL_SECS: u64 = 30;
 // Intervalo de revisión de notificaciones pendientes
 const NOTIF_CHECK_INTERVAL_SECS: u64 = 60;
 // URL base del backend de producción
-const BACKEND_URL: &str = "https://api.docktask.cl/api/v1";
+const BACKEND_URL: &str = "https://api.docktask.com/api/v1";
 
 // ─────────────────────────────────────────────
 //  MODELOS PARA SYNC

--- a/src-tauri/src/sync/worker.rs
+++ b/src-tauri/src/sync/worker.rs
@@ -6,22 +6,52 @@
 /// 2. Cada 60s: buscar notificaciones con fire_at <= now() y dispararlas
 /// 3. Detectar cambios de conectividad y sincronizar inmediatamente al volver la red
 
+use std::path::PathBuf;
 use std::time::Duration;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tokio::time;
 
 // Intervalo de sincronización de datos
 const SYNC_INTERVAL_SECS: u64 = 30;
 // Intervalo de revisión de notificaciones pendientes
 const NOTIF_CHECK_INTERVAL_SECS: u64 = 60;
-// URL del backend (se puede configurar desde tauri-plugin-store)
-const BACKEND_URL: &str = "http://localhost:8000/api/v1";
+// URL base del backend de producción
+const BACKEND_URL: &str = "https://api.docktask.cl/api/v1";
+
+// ─────────────────────────────────────────────
+//  MODELOS PARA SYNC
+// ─────────────────────────────────────────────
+
+#[derive(Debug, serde::Serialize)]
+struct TaskSyncPayload {
+    id: String,
+    project_id: String,
+    title: String,
+    description: Option<String>,
+    status: String,
+    priority: String,
+    start_date: Option<String>,
+    end_date: Option<String>,
+    assigned_to: Option<String>,
+    updated_at: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ProjectSyncPayload {
+    id: String,
+    name: String,
+    description: Option<String>,
+    updated_at: String,
+}
+
+// ─────────────────────────────────────────────
+//  PUNTO DE ENTRADA
+// ─────────────────────────────────────────────
 
 /// Punto de entrada del worker — llamado desde lib.rs setup
 pub async fn start_sync_loop(app: AppHandle) {
-    log::info!("🦀 DockTask Sync Worker iniciado");
+    log::info!("🦀 DockTask Sync Worker iniciado — backend: {}", BACKEND_URL);
 
-    // Lanzar los dos loops en paralelo
     let app_sync = app.clone();
     let app_notif = app.clone();
 
@@ -32,10 +62,28 @@ pub async fn start_sync_loop(app: AppHandle) {
 }
 
 // ─────────────────────────────────────────────
+//  HELPERS: RUTA DE LA DB
+// ─────────────────────────────────────────────
+
+/// Retorna la ruta al archivo SQLite de la app.
+/// tauri-plugin-sql guarda la DB en: <app_data_dir>/docktask.db
+fn get_db_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("No se pudo obtener app_data_dir: {}", e))?;
+
+    Ok(data_dir.join("docktask.db"))
+}
+
+// ─────────────────────────────────────────────
 //  LOOP DE SINCRONIZACIÓN DE DATOS
 // ─────────────────────────────────────────────
 
 async fn run_data_sync_loop(app: AppHandle) {
+    // Esperar un poco al inicio para que la DB esté lista
+    time::sleep(Duration::from_secs(5)).await;
+
     let mut interval = time::interval(Duration::from_secs(SYNC_INTERVAL_SECS));
 
     loop {
@@ -43,15 +91,15 @@ async fn run_data_sync_loop(app: AppHandle) {
 
         match sync_pending_changes(&app).await {
             Ok(count) if count > 0 => {
-                log::info!("Sync: {} cambios subidos al backend", count);
-                // Emitir evento a la UI para que React Query invalide el cache
+                log::info!("✅ Sync: {} cambios subidos al backend", count);
+                // Notificar a la UI para que React Query invalide el cache
                 let _ = app.emit("sync:completed", count);
             }
             Ok(_) => {
                 log::debug!("Sync: nada pendiente");
             }
             Err(e) => {
-                log::warn!("Sync error: {}", e);
+                log::warn!("⚠️  Sync error: {}", e);
             }
         }
     }
@@ -60,18 +108,188 @@ async fn run_data_sync_loop(app: AppHandle) {
 async fn sync_pending_changes(app: &AppHandle) -> Result<usize, String> {
     // Verificar conectividad primero
     if !is_online().await {
+        log::debug!("Sync: sin conexión, saltando");
         return Ok(0);
     }
 
-    // TODO: Leer registros con synced=0 de SQLite
-    // Por ahora retorna 0 (sin cambios)
-    // Implementación completa:
-    // 1. db.query("SELECT * FROM tasks WHERE synced=0")
-    // 2. Para cada tarea: POST/PATCH al backend
-    // 3. Si OK: UPDATE tasks SET synced=1 WHERE id=?
-    // 4. Manejar conflictos con Last-Write-Wins (updated_at)
+    // Obtener token JWT del store
+    let token = get_auth_token(app).await?;
+    if token.is_empty() {
+        log::debug!("Sync: sin token de sesión, saltando");
+        return Ok(0);
+    }
 
-    Ok(0)
+    let db_path = get_db_path(app)?;
+    if !db_path.exists() {
+        return Ok(0);
+    }
+
+    // Leer registros pendientes desde SQLite
+    let (pending_tasks, pending_projects) =
+        tokio::task::spawn_blocking(move || read_pending_records(&db_path))
+            .await
+            .map_err(|e| format!("Error en hilo SQLite: {}", e))??;
+
+    let mut synced_count = 0usize;
+
+    // Subir tareas pendientes
+    for task in pending_tasks {
+        match push_task_to_backend(&task, &token).await {
+            Ok(_) => {
+                mark_task_synced(&app, &task.id).await?;
+                synced_count += 1;
+                log::info!("  Tarea sincronizada: {}", task.id);
+            }
+            Err(e) => log::warn!("  Error sync tarea {}: {}", task.id, e),
+        }
+    }
+
+    // Subir proyectos pendientes
+    for project in pending_projects {
+        match push_project_to_backend(&project, &token).await {
+            Ok(_) => {
+                mark_project_synced(&app, &project.id).await?;
+                synced_count += 1;
+                log::info!("  Proyecto sincronizado: {}", project.id);
+            }
+            Err(e) => log::warn!("  Error sync proyecto {}: {}", project.id, e),
+        }
+    }
+
+    Ok(synced_count)
+}
+
+fn read_pending_records(
+    db_path: &PathBuf,
+) -> Result<(Vec<TaskSyncPayload>, Vec<ProjectSyncPayload>), String> {
+    let conn = rusqlite::Connection::open(db_path)
+        .map_err(|e| format!("No se pudo abrir SQLite: {}", e))?;
+
+    // Leer tareas no sincronizadas
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, project_id, title, description, status, priority,
+                    start_date, end_date, assigned_to, updated_at
+             FROM tasks WHERE synced = 0",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let tasks: Vec<TaskSyncPayload> = stmt
+        .query_map([], |row| {
+            Ok(TaskSyncPayload {
+                id: row.get(0)?,
+                project_id: row.get(1)?,
+                title: row.get(2)?,
+                description: row.get(3)?,
+                status: row.get(4)?,
+                priority: row.get(5)?,
+                start_date: row.get(6)?,
+                end_date: row.get(7)?,
+                assigned_to: row.get(8)?,
+                updated_at: row.get(9)?,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // Leer proyectos no sincronizados
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, description, updated_at
+             FROM projects WHERE synced = 0",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let projects: Vec<ProjectSyncPayload> = stmt
+        .query_map([], |row| {
+            Ok(ProjectSyncPayload {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                description: row.get(2)?,
+                updated_at: row.get(3)?,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok((tasks, projects))
+}
+
+async fn push_task_to_backend(task: &TaskSyncPayload, token: &str) -> Result<(), String> {
+    let client = build_http_client()?;
+    let url = format!("{}/tasks/{}", BACKEND_URL, task.id);
+
+    let res = client
+        .put(&url)
+        .bearer_auth(token)
+        .json(task)
+        .send()
+        .await
+        .map_err(|e| format!("HTTP error: {}", e))?;
+
+    if res.status().is_success() {
+        Ok(())
+    } else {
+        Err(format!("Backend respondió {}", res.status()))
+    }
+}
+
+async fn push_project_to_backend(project: &ProjectSyncPayload, token: &str) -> Result<(), String> {
+    let client = build_http_client()?;
+    let url = format!("{}/projects/{}", BACKEND_URL, project.id);
+
+    let res = client
+        .put(&url)
+        .bearer_auth(token)
+        .json(project)
+        .send()
+        .await
+        .map_err(|e| format!("HTTP error: {}", e))?;
+
+    if res.status().is_success() {
+        Ok(())
+    } else {
+        Err(format!("Backend respondió {}", res.status()))
+    }
+}
+
+async fn mark_task_synced(app: &AppHandle, task_id: &str) -> Result<(), String> {
+    let db_path = get_db_path(app)?;
+    let task_id = task_id.to_string();
+
+    tokio::task::spawn_blocking(move || {
+        let conn = rusqlite::Connection::open(&db_path)
+            .map_err(|e| format!("SQLite open error: {}", e))?;
+        conn.execute("UPDATE tasks SET synced = 1 WHERE id = ?1", [&task_id])
+            .map_err(|e| format!("SQLite update error: {}", e))?;
+        Ok::<_, String>(())
+    })
+    .await
+    .map_err(|e| format!("Spawn error: {}", e))??;
+
+    Ok(())
+}
+
+async fn mark_project_synced(app: &AppHandle, project_id: &str) -> Result<(), String> {
+    let db_path = get_db_path(app)?;
+    let project_id = project_id.to_string();
+
+    tokio::task::spawn_blocking(move || {
+        let conn = rusqlite::Connection::open(&db_path)
+            .map_err(|e| format!("SQLite open error: {}", e))?;
+        conn.execute(
+            "UPDATE projects SET synced = 1 WHERE id = ?1",
+            [&project_id],
+        )
+        .map_err(|e| format!("SQLite update error: {}", e))?;
+        Ok::<_, String>(())
+    })
+    .await
+    .map_err(|e| format!("Spawn error: {}", e))??;
+
+    Ok(())
 }
 
 // ─────────────────────────────────────────────
@@ -79,6 +297,9 @@ async fn sync_pending_changes(app: &AppHandle) -> Result<usize, String> {
 // ─────────────────────────────────────────────
 
 async fn run_notification_loop(app: AppHandle) {
+    // Esperar al inicio
+    time::sleep(Duration::from_secs(10)).await;
+
     let mut interval = time::interval(Duration::from_secs(NOTIF_CHECK_INTERVAL_SECS));
 
     loop {
@@ -86,7 +307,7 @@ async fn run_notification_loop(app: AppHandle) {
 
         match check_and_fire_notifications(&app).await {
             Ok(count) if count > 0 => {
-                log::info!("{} notificaciones disparadas", count);
+                log::info!("🔔 {} notificaciones disparadas", count);
             }
             Ok(_) => {}
             Err(e) => {
@@ -97,37 +318,123 @@ async fn run_notification_loop(app: AppHandle) {
 }
 
 async fn check_and_fire_notifications(app: &AppHandle) -> Result<usize, String> {
-    let now = chrono::Utc::now();
+    let db_path = get_db_path(app)?;
+    if !db_path.exists() {
+        return Ok(0);
+    }
 
-    // TODO: Leer pending_notifications WHERE fired=0 AND fire_at <= now
-    // Para cada una:
-    // 1. Disparar con fire_native_notification()
-    // 2. Marcar fired=1 en SQLite
+    let now_str = chrono::Utc::now().to_rfc3339();
 
-    // Ejemplo de uso:
-    // crate::commands::notifications::fire_native_notification(
-    //     app,
-    //     "DockTask ⏰",
-    //     "La tarea 'Diseño Gantt' vence en 1 hora"
-    // )?;
+    #[derive(Debug)]
+    struct PendingNotif {
+        id: String,
+        title: String,
+        body: String,
+    }
 
-    let _ = now; // suprimir warning hasta implementación completa
-    let _ = app;
-    Ok(0)
+    // Leer notificaciones cuyo fire_at ya pasó
+    let pending: Vec<PendingNotif> = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let now_str = now_str.clone();
+        move || {
+            let conn = rusqlite::Connection::open(&db_path)
+                .map_err(|e| format!("SQLite open: {}", e))?;
+
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, title, body FROM pending_notifications
+                     WHERE fired = 0 AND fire_at <= ?1",
+                )
+                .map_err(|e| e.to_string())?;
+
+            let notifs: Vec<PendingNotif> = stmt
+                .query_map([&now_str], |row| {
+                    Ok(PendingNotif {
+                        id: row.get(0)?,
+                        title: row.get(1)?,
+                        body: row.get(2)?,
+                    })
+                })
+                .map_err(|e| e.to_string())?
+                .filter_map(|r| r.ok())
+                .collect();
+
+            Ok::<_, String>(notifs)
+        }
+    })
+    .await
+    .map_err(|e| format!("Spawn error: {}", e))??;
+
+    let mut fired_count = 0usize;
+
+    for notif in pending {
+        // Disparar notificación nativa
+        match crate::commands::notifications::fire_native_notification(
+            app,
+            &notif.title,
+            &notif.body,
+        ) {
+            Ok(_) => {
+                // Marcar como disparada en SQLite
+                let db_path = db_path.clone();
+                let notif_id = notif.id.clone();
+
+                tokio::task::spawn_blocking(move || {
+                    let conn = rusqlite::Connection::open(&db_path).ok()?;
+                    conn.execute(
+                        "UPDATE pending_notifications SET fired = 1 WHERE id = ?1",
+                        [&notif_id],
+                    )
+                    .ok()
+                })
+                .await
+                .ok();
+
+                fired_count += 1;
+            }
+            Err(e) => log::warn!("Error al disparar notif {}: {}", notif.id, e),
+        }
+    }
+
+    Ok(fired_count)
 }
 
 // ─────────────────────────────────────────────
 //  HELPERS
 // ─────────────────────────────────────────────
 
-async fn is_online() -> bool {
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(3))
+async fn get_auth_token(app: &AppHandle) -> Result<String, String> {
+    use tauri_plugin_store::StoreExt;
+
+    let store = app
+        .store("auth.json")
+        .map_err(|e| format!("Error al abrir store: {}", e))?;
+
+    let token = store
+        .get("token")
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .unwrap_or_default();
+
+    Ok(token)
+}
+
+fn build_http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
         .build()
-    {
+        .map_err(|e| format!("Error al crear HTTP client: {}", e))
+}
+
+async fn is_online() -> bool {
+    let client = match build_http_client() {
         Ok(c) => c,
         Err(_) => return false,
     };
 
-    client.get("https://1.1.1.1").send().await.is_ok()
+    client
+        .get("https://1.1.1.1")
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+        .is_ok()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,9 +42,8 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "iOS": {
-      "developmentTeam": "TU_TEAM_ID_AQUI"
-    },
-    "android": {}
+    "android": {
+      "minSdkVersion": 24
+    }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,5 +45,18 @@
     "android": {
       "minSdkVersion": 24
     }
+  },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        {
+          "host": "app.docktask.com",
+          "pathPrefix": ["/task/", "/project/", "/workspace/"]
+        }
+      ],
+      "desktop": {
+        "schemes": ["docktask"]
+      }
+    }
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import {
   Navigate,
   useParams,
 } from "react-router-dom";
+import { saveTauriAuthToken, clearTauriAuthToken } from "./hooks/useTauri";
 import LoginForm from "./components/LoginForms.jsx";
 import PrivateRoute from "./components/PrivateRoute.jsx";
 import RegisterForm from "./components/RegisterForm.jsx";
@@ -34,6 +35,8 @@ function App() {
     localStorage.setItem("user", JSON.stringify(user));
     setToken(token);
     setUser(user);
+    // Persistir token en Tauri Store para que el sync worker lo lea
+    saveTauriAuthToken(token);
   };
 
   const handleLogout = () => {
@@ -41,6 +44,8 @@ function App() {
     localStorage.removeItem("user");
     setToken(null);
     setUser(null);
+    // Limpiar token del Tauri Store
+    clearTauriAuthToken();
   };
   const ultimosMensajes = [
     { id: 1, nombre: "Soporte conexión caja", estado: "pendiente", updated_at: new Date() },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,9 @@ import {
   Route,
   Navigate,
   useParams,
+  useNavigate,
 } from "react-router-dom";
-import { saveTauriAuthToken, clearTauriAuthToken } from "./hooks/useTauri";
+import { saveTauriAuthToken, clearTauriAuthToken, useDeepLink, useTauri } from "./hooks/useTauri";
 import LoginForm from "./components/LoginForms.jsx";
 import PrivateRoute from "./components/PrivateRoute.jsx";
 import RegisterForm from "./components/RegisterForm.jsx";
@@ -27,8 +28,13 @@ import CreateWorkspace from './components/CreateWorkspace';
 import EditWorkspace from './components/EditWorkspace';
 
 function App() {
+  const navigate = useNavigate();
+  const { isMobile } = useTauri();
   const [token, setToken] = useState(localStorage.getItem("token") || null);
   const [user, setUser] = useState(JSON.parse(localStorage.getItem("user")) || null);
+
+  // Deep links — notificación → navega a la ruta correcta
+  useDeepLink(navigate);
 
   const handleLogin = (token, user) => {
     localStorage.setItem("token", token);
@@ -56,7 +62,7 @@ function App() {
     <div className="min-h-screen bg-gray-50">
       <Navbar token={token} onLogout={handleLogout} />
 
-      <main className="flex justify-center items-center container mx-auto px-4 py-8">
+      <main className={`flex justify-center items-center container mx-auto px-4 py-8 ${isMobile && token ? 'pb-20' : ''}`}>
         <Routes>
           <Route
             path="/"

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,81 +1,184 @@
-import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { HomeIcon, ChatBubbleLeftIcon, ArrowRightOnRectangleIcon, UserGroupIcon, ClipboardDocumentIcon, RectangleGroupIcon } from '@heroicons/react/24/outline/index.js';
+import React, { useState } from 'react';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
+import {
+  HomeIcon,
+  ChatBubbleLeftIcon,
+  ArrowRightOnRectangleIcon,
+  UserGroupIcon,
+  ClipboardDocumentIcon,
+  RectangleGroupIcon,
+  Bars3Icon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline/index.js';
+import { useTauri } from '../hooks/useTauri';
+
+// ─────────────────────────────────────────────
+//  LINKS DE NAVEGACIÓN
+// ─────────────────────────────────────────────
+
+const NAV_LINKS = (user) => [
+  { to: '/', label: 'Inicio', icon: HomeIcon, className: '' },
+  { to: '/mis-mensajes', label: 'Mensajes', icon: ChatBubbleLeftIcon, className: 'ver-mensajes-btn' },
+  { to: '/mis-proyectos', label: 'Proyectos', icon: ClipboardDocumentIcon, className: 'ver-proyectos-btn' },
+  { to: '/mis-workspaces', label: 'Workspaces', icon: RectangleGroupIcon, className: '' },
+  ...(user?.rol === 'admin'
+    ? [{ to: '/admin', label: 'Admin', icon: UserGroupIcon, className: '' }]
+    : []),
+];
+
+// ─────────────────────────────────────────────
+//  NAVBAR PRINCIPAL
+// ─────────────────────────────────────────────
 
 const Navbar = ({ token, onLogout }) => {
   const navigate = useNavigate();
-  const user = JSON.parse(localStorage.getItem('user') || '{}');
+  const location = useLocation();
+  const { isMobile } = useTauri();
+  const [menuOpen, setMenuOpen] = useState(false);
 
+  const user = JSON.parse(localStorage.getItem('user') || '{}');
+  const links = NAV_LINKS(user);
+
+  const handleLogout = () => {
+    onLogout();
+    navigate('/login');
+    setMenuOpen(false);
+  };
+
+  // ── Navegación inferior para mobile (Android) ──
+  if (isMobile && token) {
+    return <MobileBottomNav links={links} onLogout={handleLogout} location={location} />;
+  }
+
+  // ── Navbar horizontal para desktop y web ──
   return (
     <nav className="bg-white shadow-md">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16">
+          {/* Logo / Home */}
           <div className="flex items-center">
-            <Link to="/" className="flex items-center text-gray-800 hover:text-blue-600 transition-colors duration-200">
+            <Link
+              to="/"
+              className="flex items-center text-gray-800 hover:text-blue-600 transition-colors duration-200"
+            >
               <HomeIcon className="h-6 w-6 mr-2" />
-              <span className="font-semibold text-lg">Inicio</span>
+              <span className="font-semibold text-lg">DockTask</span>
             </Link>
           </div>
 
-          <div className="flex items-center space-x-4">
+          {/* Links desktop */}
+          <div className="hidden md:flex items-center space-x-4">
             {token ? (
               <>
-                <Link
-                  to="/mis-mensajes"
-                  className="flex items-center text-gray-800 hover:text-blue-600 transition-colors duration-200 ver-mensajes-btn"
-                >
-                  <ChatBubbleLeftIcon className="h-6 w-6 mr-2" />
-                  <span className="font-semibold">Mis Mensajes</span>
-                </Link>
-                <Link
-                  to="/mis-proyectos"
-                  className="flex items-center text-gray-800 hover:text-blue-600 transition-colors duration-200 ver-proyectos-btn"
-                >
-                  <ClipboardDocumentIcon className="h-6 w-6 mr-2" />
-                  <span className="font-semibold">Mis Proyectos</span>
-                </Link>
-                <Link
-                  to="/mis-workspaces"
-                  className="flex items-center text-gray-800 hover:text-indigo-600 transition-colors duration-200"
-                >
-                  <RectangleGroupIcon className="h-6 w-6 mr-2" />
-                  <span className="font-semibold">Workspaces</span>
-                </Link>
-
-                {user.rol === 'admin' && (
+                {links.slice(1).map(({ to, label, icon: Icon, className }) => (
                   <Link
-                    to="/admin"
-                    className="flex items-center text-gray-800 hover:text-purple-600 transition-colors duration-200"
+                    key={to}
+                    to={to}
+                    className={`flex items-center text-gray-800 hover:text-blue-600 transition-colors duration-200 ${className}`}
                   >
-                    <UserGroupIcon className="h-6 w-6 mr-2" />
-                    <span className="font-semibold">Admin Panel</span>
+                    <Icon className="h-5 w-5 mr-1.5" />
+                    <span className="font-semibold">{label}</span>
                   </Link>
-                )}
-
+                ))}
                 <button
-                  onClick={() => {
-                    onLogout();
-                    navigate('/');
-                  }}
+                  onClick={handleLogout}
                   className="flex items-center text-gray-800 hover:text-red-600 transition-colors duration-200 cerrar-sesion-btn"
                 >
-                  <ArrowRightOnRectangleIcon className="h-6 w-6 mr-2" />
+                  <ArrowRightOnRectangleIcon className="h-5 w-5 mr-1.5" />
                   <span className="font-semibold">Cerrar sesión</span>
                 </button>
               </>
             ) : (
-              <Link
-                to="/"
-                className="flex items-center text-gray-800 hover:text-blue-600 transition-colors duration-200"
-              >
-                <span className="font-semibold">Iniciar sesión</span>
+              <Link to="/login" className="font-semibold text-gray-800 hover:text-blue-600">
+                Iniciar sesión
               </Link>
             )}
           </div>
+
+          {/* Hamburger para tablet/mobile web */}
+          {token && (
+            <div className="md:hidden flex items-center">
+              <button
+                onClick={() => setMenuOpen((prev) => !prev)}
+                className="p-2 rounded-md text-gray-600 hover:text-blue-600 hover:bg-gray-100"
+              >
+                {menuOpen ? (
+                  <XMarkIcon className="h-6 w-6" />
+                ) : (
+                  <Bars3Icon className="h-6 w-6" />
+                )}
+              </button>
+            </div>
+          )}
         </div>
       </div>
+
+      {/* Menú desplegable mobile web */}
+      {menuOpen && token && (
+        <div className="md:hidden border-t border-gray-100 bg-white pb-2">
+          {links.map(({ to, label, icon: Icon, className }) => (
+            <Link
+              key={to}
+              to={to}
+              onClick={() => setMenuOpen(false)}
+              className={`flex items-center px-4 py-3 text-gray-700 hover:bg-gray-50 hover:text-blue-600 ${className}`}
+            >
+              <Icon className="h-5 w-5 mr-3 text-gray-500" />
+              <span className="font-medium">{label}</span>
+            </Link>
+          ))}
+          <button
+            onClick={handleLogout}
+            className="w-full flex items-center px-4 py-3 text-gray-700 hover:bg-gray-50 hover:text-red-600 cerrar-sesion-btn"
+          >
+            <ArrowRightOnRectangleIcon className="h-5 w-5 mr-3 text-gray-500" />
+            <span className="font-medium">Cerrar sesión</span>
+          </button>
+        </div>
+      )}
     </nav>
   );
 };
 
-export default Navbar; 
+// ─────────────────────────────────────────────
+//  BOTTOM NAV (solo Tauri Android)
+// ─────────────────────────────────────────────
+
+const MobileBottomNav = ({ links, onLogout, location }) => {
+  // Mostrar máximo 4 links + logout en bottom nav
+  const visibleLinks = links.slice(0, 4);
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-200 flex items-center justify-around h-16 safe-area-pb">
+      {visibleLinks.map(({ to, label, icon: Icon }) => {
+        const isActive = location.pathname === to ||
+          (to !== '/' && location.pathname.startsWith(to));
+        return (
+          <Link
+            key={to}
+            to={to}
+            className={`flex flex-col items-center justify-center flex-1 h-full pt-1 transition-colors duration-150 ${
+              isActive
+                ? 'text-blue-600'
+                : 'text-gray-500 hover:text-blue-500'
+            }`}
+          >
+            <Icon className="h-6 w-6" />
+            <span className="text-[10px] mt-0.5 font-medium">{label}</span>
+          </Link>
+        );
+      })}
+
+      {/* Botón logout */}
+      <button
+        onClick={onLogout}
+        className="flex flex-col items-center justify-center flex-1 h-full pt-1 text-gray-500 hover:text-red-500 transition-colors duration-150"
+      >
+        <ArrowRightOnRectangleIcon className="h-6 w-6" />
+        <span className="text-[10px] mt-0.5 font-medium">Salir</span>
+      </button>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/src/hooks/useTauri.js
+++ b/src/hooks/useTauri.js
@@ -1,0 +1,209 @@
+/**
+ * useTauri.js — Integración React ↔ Tauri
+ *
+ * Detecta si la app corre dentro de Tauri (desktop/Android) o en el browser (web).
+ * Expone helpers para invocar comandos nativos de forma segura.
+ *
+ * Uso:
+ *   const { isTauri, platform, invoke, scheduleReminder } = useTauri();
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+// Tauri v2: los módulos se importan desde @tauri-apps/api
+let tauriInvoke = null;
+let tauriPlatform = null;
+let tauriListen = null;
+
+// Importación dinámica para no romper la app cuando corre en el browser
+(async () => {
+  if (typeof window !== "undefined" && window.__TAURI__) {
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      const { platform } = await import("@tauri-apps/plugin-os");
+      const { listen } = await import("@tauri-apps/api/event");
+      tauriInvoke = invoke;
+      tauriPlatform = platform;
+      tauriListen = listen;
+    } catch (e) {
+      console.warn("[useTauri] No se pudo cargar Tauri API:", e);
+    }
+  }
+})();
+
+// ─────────────────────────────────────────────
+//  HOOK PRINCIPAL
+// ─────────────────────────────────────────────
+
+export function useTauri() {
+  const isTauri = typeof window !== "undefined" && !!window.__TAURI__;
+  const [platform, setPlatform] = useState(null); // "android" | "linux" | "windows" | "macos" | null (web)
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+
+  useEffect(() => {
+    if (!isTauri) return;
+
+    // Detectar plataforma
+    (async () => {
+      try {
+        if (tauriPlatform) {
+          const p = await tauriPlatform();
+          setPlatform(p);
+        }
+      } catch (e) {
+        console.warn("[useTauri] Error al detectar plataforma:", e);
+      }
+    })();
+
+    // Escuchar eventos de sync completado
+    let unlisten;
+    if (tauriListen) {
+      tauriListen("sync:completed", (event) => {
+        console.log(`[DockTask Sync] ${event.payload} cambios sincronizados`);
+        // Emitir evento custom para que los hooks de React Query invaliden
+        window.dispatchEvent(new CustomEvent("docktask:synced", { detail: event.payload }));
+      }).then((fn) => {
+        unlisten = fn;
+      });
+    }
+
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, [isTauri]);
+
+  // Detectar cambios de conectividad
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  // ── Helpers de plataforma ──
+
+  const isMobile = platform === "android" || platform === "ios";
+  const isDesktop = platform === "linux" || platform === "windows" || platform === "macos";
+
+  // ── invoke seguro ──
+
+  const invoke = useCallback(async (command, args = {}) => {
+    if (!isTauri || !tauriInvoke) {
+      throw new Error(`Comando Tauri no disponible en el browser: ${command}`);
+    }
+    return tauriInvoke(command, args);
+  }, [isTauri]);
+
+  // ── Helpers de alto nivel ──
+
+  /**
+   * Programa un recordatorio para una tarea.
+   * @param {string} taskId
+   * @param {string} title
+   * @param {string} body
+   * @param {Date} fireAt
+   */
+  const scheduleReminder = useCallback(
+    async (taskId, title, body, fireAt) => {
+      if (!isTauri) return null;
+
+      const reminderId = `rem-${taskId}-${Date.now()}`;
+      return invoke("schedule_task_reminder", {
+        reminder: {
+          id: reminderId,
+          task_id: taskId,
+          title,
+          body,
+          fire_at: fireAt.toISOString(),
+          repeat: null,
+        },
+      });
+    },
+    [isTauri, invoke]
+  );
+
+  /**
+   * Cancela un recordatorio por ID.
+   */
+  const cancelReminder = useCallback(
+    async (reminderId) => {
+      if (!isTauri) return;
+      return invoke("cancel_reminder", { reminder_id: reminderId });
+    },
+    [isTauri, invoke]
+  );
+
+  /**
+   * Lista los recordatorios pendientes.
+   */
+  const getPendingReminders = useCallback(async () => {
+    if (!isTauri) return [];
+    return invoke("get_pending_notifications");
+  }, [isTauri, invoke]);
+
+  /**
+   * Verifica si hay conexión a internet (via Rust).
+   */
+  const checkNetwork = useCallback(async () => {
+    if (!isTauri) return navigator.onLine;
+    return invoke("get_network_status");
+  }, [isTauri, invoke]);
+
+  /**
+   * Agrega una tarea al calendario del OS.
+   */
+  const addToCalendar = useCallback(
+    async (event) => {
+      if (!isTauri) return null;
+      return invoke("add_to_os_calendar", { event });
+    },
+    [isTauri, invoke]
+  );
+
+  return {
+    isTauri,
+    platform,
+    isMobile,
+    isDesktop,
+    isOnline,
+    invoke,
+    scheduleReminder,
+    cancelReminder,
+    getPendingReminders,
+    checkNetwork,
+    addToCalendar,
+  };
+}
+
+// ─────────────────────────────────────────────
+//  HELPER: guardar token en Tauri Store
+//  (para que el sync worker lo pueda leer)
+// ─────────────────────────────────────────────
+
+export async function saveTauriAuthToken(token) {
+  if (typeof window === "undefined" || !window.__TAURI__) return;
+  try {
+    const { load } = await import("@tauri-apps/plugin-store");
+    const store = await load("auth.json", { autoSave: true });
+    await store.set("token", token);
+    await store.save();
+  } catch (e) {
+    console.warn("[useTauri] No se pudo guardar token en store:", e);
+  }
+}
+
+export async function clearTauriAuthToken() {
+  if (typeof window === "undefined" || !window.__TAURI__) return;
+  try {
+    const { load } = await import("@tauri-apps/plugin-store");
+    const store = await load("auth.json", { autoSave: true });
+    await store.delete("token");
+    await store.save();
+  } catch (e) {
+    console.warn("[useTauri] No se pudo limpiar token del store:", e);
+  }
+}

--- a/src/hooks/useTauri.js
+++ b/src/hooks/useTauri.js
@@ -32,6 +32,78 @@ let tauriListen = null;
 })();
 
 // ─────────────────────────────────────────────
+//  HOOK: DEEP LINKS
+//  Escucha deeplink:navigate y convierte la URL
+//  en una ruta de React Router.
+//
+//  Uso:
+//    useDeepLink(navigate);
+// ─────────────────────────────────────────────
+
+export function useDeepLink(navigate) {
+  useEffect(() => {
+    if (!tauriListen) return;
+
+    let unlisten;
+
+    // Escuchar evento emitido desde lib.rs
+    tauriListen("deeplink:navigate", (event) => {
+      const raw = event.payload; // ej: "docktask://task/abc123"
+      const path = parseDeepLinkPath(raw);
+      if (path) {
+        console.log("[DeepLink] Navegando a:", path);
+        navigate(path);
+      }
+    }).then((fn) => {
+      unlisten = fn;
+    });
+
+    // También revisar si la app se abrió con un deep link (cold start)
+    (async () => {
+      try {
+        const { getCurrent } = await import("@tauri-apps/plugin-deep-link");
+        const urls = await getCurrent();
+        if (urls && urls.length > 0) {
+          const path = parseDeepLinkPath(urls[0]);
+          if (path) navigate(path);
+        }
+      } catch (_) {}
+    })();
+
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, [navigate]);
+}
+
+/**
+ * Convierte una URL de deep link en una ruta React Router.
+ *
+ * Ejemplos:
+ *   docktask://task/abc123        → /tarea/abc123
+ *   https://app.docktask.com/task/abc123 → /tarea/abc123
+ *   docktask://project/xyz        → /mis-proyectos/xyz
+ *   docktask://workspace/w1       → /mis-workspaces/w1
+ */
+function parseDeepLinkPath(url) {
+  try {
+    const u = new URL(url.replace("docktask://", "https://deep.link/"));
+    const parts = u.pathname.split("/").filter(Boolean);
+    const [type, id] = parts;
+
+    switch (type) {
+      case "task":      return `/tarea/${id}`;
+      case "project":   return `/mis-proyectos/${id}`;
+      case "workspace": return `/mis-workspaces/${id}`;
+      case "gantt":     return `/mis-proyectos/${id}/gantt`;
+      default:          return null;
+    }
+  } catch (_) {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────
 //  HOOK PRINCIPAL
 // ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Sprint 1 + Sprint 2 — Arquitectura capa nativa completa

> Solo Android (iOS descartado). Backend: `https://api.docktask.com/api/v1`

---

### Sprint 1 — Fundación
- `tauri.conf.json`: iOS eliminado, Android `minSdkVersion 24`
- `capabilities/desktop.json` + `capabilities/mobile.json` separados
- `sync/worker.rs`: SQLite real (rusqlite) + sync HTTP al backend
- `notifications.rs`: persistencia real en SQLite (INSERT/UPDATE/SELECT)
- `useTauri.js`: hook de integración React ↔ Tauri (platform, invoke, helpers)
- `App.jsx`: token en Tauri Store al login/logout
- `package.json`: plugin-os, plugin-store, plugin-notification agregados

### Sprint 2 — Deep links, UI mobile y CI/CD

**Deep links**
- Scheme `docktask://` (desktop) + `https://app.docktask.com` (Android)
- `lib.rs`: plugin deep-link registrado + handler → emit a React
- `useDeepLink(navigate)`: escucha evento + cold start, parsea URL → ruta React Router
  - `docktask://task/id` → `/tarea/id`
  - `docktask://project/id` → `/mis-proyectos/id`
  - `docktask://gantt/id` → `/mis-proyectos/id/gantt`

**UI touch-first**
- `Navbar.jsx` rediseñado:
  - Desktop: navbar horizontal sin cambios
  - Tablet/web: hamburger menu desplegable
  - **Tauri Android**: bottom navigation bar (iconos + labels + active state)
- `App.jsx`: `pb-20` automático cuando hay bottom nav

**CI/CD Android**
- `.github/workflows/android.yml`
  - Triggers: push a `main` (paths relevantes) + `workflow_dispatch`
  - Stack: JDK 17 + Android SDK (NDK 27 + API 34) + Rust (4 targets Android)
  - Debug por defecto; release firmado con `workflow_dispatch --release true`
  - APK como artifact (14 días)

### Secrets necesarios para build release
```
ANDROID_KEYSTORE_BASE64
ANDROID_KEY_ALIAS
ANDROID_KEY_PASSWORD
ANDROID_STORE_PASSWORD
```
