### PR TITLE
fix(android): corregir firma APK y agregar estado urgente

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -128,18 +128,22 @@ jobs:
 
           echo "APK sin firmar: $UNSIGNED"
 
+          # Zipalign (alinear antes de firmar)
           $BUILD_TOOLS/zipalign -v -p 4 "$UNSIGNED" /tmp/docktask-aligned.apk
 
+          # Firmar con apksigner
+          # Nota: PKCS12/JKS keystores requieren que key-pass = store-pass
           $BUILD_TOOLS/apksigner sign \
             --ks "$KEYSTORE_PATH" \
             --ks-key-alias "${{ secrets.ANDROID_KEY_ALIAS }}" \
             --ks-pass "pass:${{ secrets.ANDROID_STORE_PASSWORD }}" \
-            --key-pass "pass:${{ secrets.ANDROID_KEY_PASSWORD }}" \
+            --key-pass "pass:${{ secrets.ANDROID_STORE_PASSWORD }}" \
             --out /tmp/docktask-signed.apk \
             /tmp/docktask-aligned.apk
 
+          # Verificar firma - si falla, el step falla
           $BUILD_TOOLS/apksigner verify --verbose /tmp/docktask-signed.apk
-          echo "✅ APK firmado correctamente"
+          echo "✅ APK firmado y verificado correctamente"
 
       # ── Subir APK firmado (push/dispatch) ─────────────────────────
       - name: Upload signed APK


### PR DESCRIPTION
## Summary

- **Corregir firma de APK Android**: El APK quedaba unsigned porque `--key-pass` usaba un secret diferente (`ANDROID_KEY_PASSWORD`) cuando los keystores JKS/PKCS12 requieren que `key-pass = store-pass`
- **Agregar estado urgente**: Nueva opción de estado con color rojo para tareas urgentes
- **Mejorar workflow Android**: Cleanup garantizado del keystore, validaciones explícitas y comentarios

## Cambios principales

### Android workflow
- Usar `ANDROID_STORE_PASSWORD` para ambos `--ks-pass` y `--key-pass`
- Agregar comentarios explicativos al proceso de firma
- Mejorar manejo de errores y cleanup

### UI
- Nuevo estado "Urgente" con color rojo
- Cambiar botones a verde oliva

## Secrets a eliminar en GitHub (ya no se usan)
- `ANDROID_DEBUG_KEYSTORE_BASE64`
- `ANDROID_KEY_PASSWORD`

## Testing
- [ ] Build Android en CI genera APK firmado correctamente
- [ ] APK se instala en dispositivo Android sin errores