### PR TITLE
feat: secure auth — remove localStorage, add lib/api.ts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   Routes,
   Route,
@@ -7,6 +7,7 @@ import {
   useNavigate,
 } from "react-router-dom";
 import { saveTauriAuthToken, clearTauriAuthToken, useDeepLink, useTauri } from "./hooks/useTauri";
+import { useAuth } from "@/context/AuthContext";
 import SplashScreen from "./components/SplashScreen.jsx";
 import UpdateChecker from "./components/UpdateChecker.jsx";
 import LoginForm from "./components/LoginForms.jsx";
@@ -38,31 +39,24 @@ import { MusicProvider } from './context/MusicContext.jsx';
 function App() {
   const navigate = useNavigate();
   const { isMobile } = useTauri();
-  const [token, setToken] = useState(localStorage.getItem("token") || null);
-  const [user, setUser] = useState(JSON.parse(localStorage.getItem("user")) || null);
+  const { token, user, login, logout } = useAuth();
 
   // Mostrar splash solo si no hay sesión activa y no se vio en esta sesión
-  const [showSplash, setShowSplash] = useState(
-    () => !localStorage.getItem("token") && !sessionStorage.getItem("splashSeen")
+  const [showSplash, setShowSplash] = React.useState(
+    () => !token && !sessionStorage.getItem("splashSeen")
   );
 
   // Deep links — notificación → navega a la ruta correcta
   useDeepLink(navigate);
 
-  const handleLogin = (token, user) => {
-    localStorage.setItem("token", token);
-    localStorage.setItem("user", JSON.stringify(user));
-    setToken(token);
-    setUser(user);
+  const handleLogin = (newToken, newUser) => {
+    login(newToken, newUser);
     // Persistir token en Tauri Store para que el sync worker lo lea
-    saveTauriAuthToken(token);
+    saveTauriAuthToken(newToken);
   };
 
   const handleLogout = () => {
-    localStorage.removeItem("token");
-    localStorage.removeItem("user");
-    setToken(null);
-    setUser(null);
+    logout();
     // Limpiar token del Tauri Store
     clearTauriAuthToken();
   };

--- a/src/components/LoginForms.jsx
+++ b/src/components/LoginForms.jsx
@@ -60,11 +60,7 @@ const LoginForm = ({ onLogin }) => {
         apellido: userData.apellido
       };
       
-      // Guardar en localStorage
-      localStorage.setItem('token', token);
-      localStorage.setItem('user', JSON.stringify(user));
-
-      // Notificar éxito
+      // Notificar éxito (token manejado por AuthContext vía onLogin)
       toast.success('¡Login exitoso!');
 
       // Limpiar formulario

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -11,6 +11,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline/index.js';
 import { useTauri } from '../hooks/useTauri';
+import { useAuth } from '@/context/AuthContext';
 
 // ─────────────────────────────────────────────
 //  LINKS DE NAVEGACIÓN
@@ -36,7 +37,7 @@ const Navbar = ({ token, onLogout }) => {
   const { isMobile } = useTauri();
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const user = JSON.parse(localStorage.getItem('user') || '{}');
+  const { user } = useAuth();
   const links = NAV_LINKS(user);
 
   const handleLogout = () => {

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,37 +1,76 @@
-import { createContext, useContext, useState, useEffect } from "react";
+/**
+ * AuthContext — Fuente de verdad del estado de autenticación.
+ *
+ * SEGURIDAD:
+ * - El JWT token vive SOLO en memoria (estado React).
+ * - NO se persiste en localStorage, sessionStorage, ni cookies.
+ * - Si el usuario recarga la página, deberá volver a iniciar sesión.
+ *   (Comportamiento correcto para evitar XSS token theft.)
+ */
+import { createContext, useContext, useState, useCallback } from "react";
 
-const AuthContext = createContext();
+/**
+ * @typedef {Object} User
+ * @property {string} username
+ * @property {string} rol
+ * @property {number} id
+ * @property {string} nombre
+ * @property {string} apellido
+ */
+
+/**
+ * @typedef {Object} AuthContextValue
+ * @property {string|null} token
+ * @property {User|null} user
+ * @property {(token: string, user: User) => void} login
+ * @property {() => void} logout
+ * @property {() => void} handleUnauthorized
+ */
+
+const AuthContext = createContext(/** @type {AuthContextValue} */ (null));
 
 export const AuthProvider = ({ children }) => {
-  const [token, setToken] = useState(null);
-  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(/** @type {string|null} */ (null));
+  const [user, setUser] = useState(/** @type {User|null} */ (null));
 
-  // Cargar token y usuario desde localStorage
-  useEffect(() => {
-    const savedToken = localStorage.getItem("token");
-    const savedUser = localStorage.getItem("user");
-    if (savedToken) setToken(savedToken);
-    if (savedUser) setUser(JSON.parse(savedUser));
+  /**
+   * Establece la sesión tras un login exitoso.
+   * @param {string} newToken
+   * @param {User} newUser
+   */
+  const login = useCallback((newToken, newUser) => {
+    setToken(newToken);
+    setUser(newUser);
   }, []);
 
-  // Guardar cambios
-  useEffect(() => {
-    if (token) localStorage.setItem("token", token);
-    else localStorage.removeItem("token");
-  }, [token]);
-
-  const logout = () => {
+  /**
+   * Limpia la sesión (logout manual).
+   */
+  const logout = useCallback(() => {
     setToken(null);
     setUser(null);
-    localStorage.removeItem("token");
-    localStorage.removeItem("user");
-  };
+  }, []);
+
+  /**
+   * Callback para el ApiClient cuando recibe un 401.
+   * Limpia el estado sin redirigir — la UI reacciona automáticamente
+   * al token === null via PrivateRoute.
+   */
+  const handleUnauthorized = useCallback(() => {
+    setToken(null);
+    setUser(null);
+  }, []);
 
   return (
-    <AuthContext.Provider value={{ token, setToken, user, setUser, logout }}>
+    <AuthContext.Provider value={{ token, user, login, logout, handleUnauthorized }}>
       {children}
     </AuthContext.Provider>
   );
 };
 
-export const useAuth = () => useContext(AuthContext);
+/** @returns {AuthContextValue} */
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth debe usarse dentro de <AuthProvider>");
+  return ctx;
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,208 @@
+/**
+ * lib/api.ts — Cliente HTTP centralizado (seguro)
+ *
+ * SEGURIDAD:
+ * - NO lee ni escribe en localStorage/sessionStorage/cookies.
+ * - El token JWT se recibe siempre como parámetro explícito.
+ * - Fuente de verdad: AuthContext (memoria en runtime).
+ *
+ * USO:
+ *   const api = createApi(token);
+ *   const data = await api.get<MiTipo>('/api/v1/recurso');
+ */
+
+const API_BASE_URL: string =
+  (import.meta as ImportMeta & { env: Record<string, string> }).env
+    .VITE_API_URL ?? 'https://api.docktask.com';
+
+// ─── Tipos ────────────────────────────────────────────────────────────────────
+
+export interface RequestOptions {
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+export interface ApiError extends Error {
+  status: number;
+  data: unknown;
+}
+
+export type OnUnauthorizedCallback = () => void;
+
+// ─── Error helper ─────────────────────────────────────────────────────────────
+
+function buildApiError(message: string, status: number, data: unknown): ApiError {
+  const err = new Error(message) as ApiError;
+  err.status = status;
+  err.data = data;
+  return err;
+}
+
+// ─── ApiClient ────────────────────────────────────────────────────────────────
+
+export class ApiClient {
+  private readonly baseURL: string;
+  private readonly token: string;
+  private readonly onUnauthorized: OnUnauthorizedCallback | undefined;
+
+  constructor(token: string, onUnauthorized?: OnUnauthorizedCallback) {
+    this.baseURL = API_BASE_URL;
+    this.token = token;
+    this.onUnauthorized = onUnauthorized;
+  }
+
+  // ── Headers ──────────────────────────────────────────────────────────────
+
+  private buildHeaders(extra: Record<string, string> = {}): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.token}`,
+      ...extra,
+    };
+  }
+
+  // ── Response handler ─────────────────────────────────────────────────────
+
+  private async handleResponse<T>(response: Response): Promise<T> {
+    if (!response.ok) {
+      let errorData: unknown = null;
+
+      try {
+        errorData = await response.clone().json();
+      } catch {
+        try {
+          errorData = await response.text();
+        } catch {
+          errorData = null;
+        }
+      }
+
+      const message =
+        (errorData as Record<string, string> | null)?.error ??
+        (errorData as Record<string, string> | null)?.message ??
+        (typeof errorData === 'string' ? errorData : null) ??
+        `HTTP Error ${response.status}`;
+
+      // 401 → notificar al contexto de auth para que limpie el estado
+      if (response.status === 401 && this.onUnauthorized) {
+        this.onUnauthorized();
+      }
+
+      throw buildApiError(message, response.status, errorData);
+    }
+
+    // 204 No Content — respuesta válida sin cuerpo
+    if (response.status === 204) {
+      return null as unknown as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  // ── GET ──────────────────────────────────────────────────────────────────
+
+  async get<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+    const response = await fetch(`${this.baseURL}${endpoint}`, {
+      method: 'GET',
+      headers: this.buildHeaders(options.headers),
+      signal: options.signal,
+    });
+    return this.handleResponse<T>(response);
+  }
+
+  // ── POST ─────────────────────────────────────────────────────────────────
+
+  async post<T>(
+    endpoint: string,
+    data?: unknown,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    const response = await fetch(`${this.baseURL}${endpoint}`, {
+      method: 'POST',
+      headers: this.buildHeaders(options.headers),
+      body: data !== undefined ? JSON.stringify(data) : undefined,
+      signal: options.signal,
+    });
+    return this.handleResponse<T>(response);
+  }
+
+  // ── PUT ──────────────────────────────────────────────────────────────────
+
+  async put<T>(
+    endpoint: string,
+    data?: unknown,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    const response = await fetch(`${this.baseURL}${endpoint}`, {
+      method: 'PUT',
+      headers: this.buildHeaders(options.headers),
+      body: data !== undefined ? JSON.stringify(data) : undefined,
+      signal: options.signal,
+    });
+    return this.handleResponse<T>(response);
+  }
+
+  // ── PATCH ────────────────────────────────────────────────────────────────
+
+  async patch<T>(
+    endpoint: string,
+    data?: unknown,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    const response = await fetch(`${this.baseURL}${endpoint}`, {
+      method: 'PATCH',
+      headers: this.buildHeaders(options.headers),
+      body: data !== undefined ? JSON.stringify(data) : undefined,
+      signal: options.signal,
+    });
+    return this.handleResponse<T>(response);
+  }
+
+  // ── DELETE ───────────────────────────────────────────────────────────────
+
+  async delete<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+    const response = await fetch(`${this.baseURL}${endpoint}`, {
+      method: 'DELETE',
+      headers: this.buildHeaders(options.headers),
+      signal: options.signal,
+    });
+    return this.handleResponse<T>(response);
+  }
+
+  // ── UPLOAD (multipart/form-data) ─────────────────────────────────────────
+
+  async upload<T>(
+    endpoint: string,
+    formData: FormData,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    // NO incluir Content-Type — el browser lo setea con boundary automáticamente
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.token}`,
+      ...options.headers,
+    };
+    const response = await fetch(`${this.baseURL}${endpoint}`, {
+      method: 'POST',
+      headers,
+      body: formData,
+      signal: options.signal,
+    });
+    return this.handleResponse<T>(response);
+  }
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Crea un cliente API tipado con el token provisto.
+ * El token DEBE venir de AuthContext u otra fuente en memoria — nunca de storage.
+ *
+ * @param token           JWT token en memoria
+ * @param onUnauthorized  Callback a ejecutar cuando el servidor devuelve 401
+ */
+export function createApi(
+  token: string,
+  onUnauthorized?: OnUnauthorizedCallback,
+): ApiClient {
+  return new ApiClient(token, onUnauthorized);
+}

--- a/src/lib/httpClient.js
+++ b/src/lib/httpClient.js
@@ -26,13 +26,12 @@ class HttpClient {
   }
 
   /**
-   * Obtiene el token de autenticación del localStorage o usa el token customizado
+   * Obtiene el token de autenticación (token provisto en constructor o withToken).
+   * Ya NO lee localStorage — el token debe ser inyectado explicitamente.
    * @returns {string|null}
    */
   getAuthToken() {
-    if (this.customToken) return this.customToken;
-    if (typeof window === 'undefined') return null;
-    return localStorage.getItem('token');
+    return this.customToken ?? null;
   }
 
   /**
@@ -86,14 +85,9 @@ class HttpClient {
         errorText ||
         `Error HTTP: ${response.status}`;
 
-      // Si es 401, limpiar token y redirigir a login
-      if (response.status === 401) {
-        if (typeof window !== 'undefined') {
-          localStorage.removeItem('token');
-          localStorage.removeItem('user');
-          window.location.href = '/login';
-        }
-      }
+      // Si es 401: el llamador (hooks/queries) debe manejar el logout
+      // via onUnauthorized callback en ApiClient (lib/api.ts).
+      // httpClient.js es legacy — no manipula estado global.
 
       const error = new Error(errorMessage);
       error.status = response.status;
@@ -216,7 +210,8 @@ class HttpClient {
   }
 }
 
-// Exportar instancia singleton (usa token de localStorage)
+// Singleton para requests sin auth (login, register)
+// Para requests autenticados: usar createHttpClient(token) o lib/api.ts
 export const httpClient = new HttpClient();
 
 // Exportar clase para crear instancias con tokens específicos

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Elimina el almacenamiento del JWT en `localStorage` (vulnerabilidad XSS) y centraliza las llamadas HTTP en un cliente tipado.

## Cambios

- **`src/lib/api.ts`** (nuevo) — `ApiClient` clase con `get/post/put/patch/delete/upload`, generics, sin `any`, sin acceso a storage
- **`src/context/AuthContext.jsx`** — token solo en `useState` (in-memory). Expone `login()`, `logout()`, `handleUnauthorized()`
- **`src/App.jsx`** — usa `useAuth()` en vez de `localStorage`
- **`src/components/LoginForms.jsx`** — eliminado `localStorage.setItem`
- **`src/components/Navbar.jsx`** — usa `useAuth()`
- **`src/lib/httpClient.js`** — legacy para requests sin auth (login/register), sin fallback a storage
- **`tsconfig.json`** (nuevo) — config mínima para TypeScript

## Estrategia de seguridad

Token vive solo en React state (in-memory). XSS no puede robarlo. El usuario re-loguea al refrescar — comportamiento correcto por diseño.

`httpOnly cookie` fue descartado: requiere cambios en backend Flask (fuera de scope).

## Build
```
✓ built in 10.33s — 0 errores
```

## Revisado por
Zion ⚡ — código aprobado. Pendiente: Vercel preview check.