### PR TITLE
fix(ci): fix Android build — remove --mode from cargo args, update NDK to 29

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 env:
-  NDK_VERSION: "27.0.12077973"
+  NDK_VERSION: "29.0.14206865"
   ANDROID_API: "34"
 
 jobs:
@@ -93,7 +93,7 @@ jobs:
 
       # ── Build APK (release sin firmar) ────────────────────────────
       - name: Build Android APK
-        run: npm run tauri:build:android -- --apk
+        run: npm run tauri:build:android
         env:
           NDK_HOME: ${{ env.NDK_HOME }}
           ANDROID_NDK_HOME: ${{ env.NDK_HOME }}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "tauri": "tauri",
     "tauri:dev": "tauri dev -- --mode development",
     "tauri:build": "tauri build -- --mode production",
-    "tauri:build:android": "tauri android build --apk -- --mode production",
+    "tauri:build:android": "tauri android build --apk",
     "tauri:dev:android": "tauri android dev -- --mode development"
   },
   "dependencies": {


### PR DESCRIPTION
## Problema

El workflow `Build Android` fallaba con:
```
error: unexpected argument '--mode' found
cargo build ... --mode production
```

Y además el NDK `27.0.12077973` ya no está disponible en los runners `ubuntu-latest`.

## Causa raíz

El script `tauri:build:android` en `package.json` tenía `-- --mode production` al final:
```json
"tauri:build:android": "tauri android build --apk -- --mode production"
```

En Tauri v2, los args después de `--` se pasan directamente a `cargo build`, **no a Vite**. `cargo` no reconoce `--mode`, causando el error. El flag `--mode` es de Vite y no aplica a la compilación Rust.

Además, el workflow llamaba `npm run tauri:build:android -- --apk`, duplicando el flag `--apk` que ya estaba en el script.

## Fixes

### 1. `package.json`
- Eliminado `-- --mode production` del script `tauri:build:android`
- El frontend ya se pre-construye en el step `Build frontend` (`npm run build`), así que el flag de modo no es necesario en el build Android

### 2. `.github/workflows/android.yml`
- NDK actualizado: `27.0.12077973` → `29.0.14206865` (versión disponible en runners actuales)
- Eliminado `-- --apk` duplicado del step `Build Android APK` (el script ya incluye `--apk`)

## Archivos cambiados
- `package.json` — script `tauri:build:android` corregido
- `.github/workflows/android.yml` — NDK actualizado, comando limpiado

Fixes run [#24935957494](https://github.com/sti-chile/docktask_frontend/actions/runs/24935957494)