### PR TITLE
🎨 LinkPreview Component — Obscura Phase 1 (Frontend)

### DIFF
--- a/src/api/previewApi.js
+++ b/src/api/previewApi.js
@@ -1,0 +1,27 @@
+/**
+ * Link Preview API
+ * Llama al endpoint de Obscura para extraer metadata de URLs.
+ */
+
+export async function fetchLinkPreview(url) {
+  const token = localStorage.getItem('access_token');
+  const res = await fetch('/api/v1/preview/link', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + token,
+    },
+    body: JSON.stringify({ url }),
+  });
+  if (!res.ok) throw new Error('Failed to fetch preview');
+  return res.json();
+}
+
+/**
+ * Detecta URLs en un texto
+ */
+export function extractFirstUrl(text) {
+  if (!text) return null;
+  const match = text.match(/https?:\/\/[^\s<>"']+/i);
+  return match ? match[0] : null;
+}

--- a/src/components/CreateMessage.jsx
+++ b/src/components/CreateMessage.jsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useMensajesQuery } from '../hooks/useMensajesQuery';
 import { useProjectQuery } from '../hooks/useProjectQuery';
 import EstadoSelect from './EstadoSelect';
+import LinkPreview from './LinkPreview';
+import { extractFirstUrl } from '../api/previewApi';
 
 const CreateMessage = ({ token }) => {
   const navigate = useNavigate();
@@ -15,6 +17,18 @@ const CreateMessage = ({ token }) => {
   const { proyectos } = useProjectQuery(token);
 
   const [loading, setLoading] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const debounceRef = useRef(null);
+
+  // Detectar URLs en el campo mensaje con debounce de 1s
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const url = extractFirstUrl(formData.mensaje);
+      setPreviewUrl(url);
+    }, 600);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [formData.mensaje]);
 
   const [formData, setFormData] = useState({
     nombre: '',
@@ -111,8 +125,9 @@ const CreateMessage = ({ token }) => {
                 required
                 rows="4"
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder="Ingrese el contenido del mensaje"
+                placeholder="Ingrese el contenido del mensaje (puede incluir enlaces)"
               />
+              {previewUrl && <LinkPreview url={previewUrl} />}
             </div>
 
             {!projectId && (

--- a/src/components/EditMessages.jsx
+++ b/src/components/EditMessages.jsx
@@ -1,11 +1,24 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { createHttpClient, httpClient } from '@/lib/httpClient';
+import LinkPreview from './LinkPreview';
+import { extractFirstUrl } from '../api/previewApi';
 
 function EditMessage({ token }) {
   const { id } = useParams();
   const navigate = useNavigate();
   const [mensaje, setMensaje] = useState("");
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const debounceRef = useRef(null);
+
+  // Detectar URLs con debounce
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setPreviewUrl(extractFirstUrl(mensaje));
+    }, 600);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [mensaje]);
 
   useEffect(() => {
     const api = token ? createHttpClient(token) : httpClient;
@@ -46,7 +59,9 @@ function EditMessage({ token }) {
             onChange={(e) => setMensaje(e.target.value)}
             rows="5"
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            placeholder="Edite el contenido del mensaje"
           />
+          {previewUrl && <LinkPreview url={previewUrl} />}
         </div>
         <div className="flex gap-4">
           <button

--- a/src/components/LinkPreview.jsx
+++ b/src/components/LinkPreview.jsx
@@ -1,0 +1,98 @@
+import React, { useState, useEffect } from 'react';
+import { fetchLinkPreview } from '../api/previewApi';
+import '../styles/LinkPreview.css';
+
+/**
+ * LinkPreview — Tarjeta de previsualización de enlaces.
+ * Extrae metadata (OG tags, título, descripción, favicon) vía Obscura.
+ * 
+ * @param {{ url: string }} props
+ */
+const LinkPreview = ({ url }) => {
+  const [state, setState] = useState('loading'); // loading | loaded | error
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    if (!url) return;
+
+    let cancelled = false;
+    setState('loading');
+    setData(null);
+
+    fetchLinkPreview(url)
+      .then((result) => {
+        if (!cancelled) {
+          setData(result);
+          setState('loaded');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState('error');
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [url]);
+
+  // ─── Loading Skeleton ───
+  if (state === 'loading') {
+    return (
+      <div className="link-preview-skeleton" aria-label="Cargando vista previa...">
+        <div className="sk-thumb" />
+        <div className="sk-content">
+          <div className="sk-line" />
+          <div className="sk-line" />
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Error Fallback ───
+  if (state === 'error' || !data) {
+    return (
+      <div className="link-preview-error">
+        <a href={url} target="_blank" rel="noopener noreferrer">
+          {url}
+        </a>
+      </div>
+    );
+  }
+
+  // ─── Loaded Card ───
+  const { title, description, image, favicon, site_name } = data;
+  const domain = new URL(url).hostname;
+
+  return (
+    <div className="link-preview-card">
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        {/* Thumbnail */}
+        <div className="link-preview-thumb">
+          {image ? (
+            <img src={image} alt="" loading="lazy" referrerPolicy="no-referrer" />
+          ) : favicon ? (
+            <img src={favicon} alt="" className="link-preview-favicon-only" referrerPolicy="no-referrer" />
+          ) : (
+            <span style={{ fontSize: 24, opacity: 0.3 }}>🔗</span>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="link-preview-content">
+          <div className="link-preview-title">
+            {title || domain}
+          </div>
+          {description && (
+            <div className="link-preview-desc">{description}</div>
+          )}
+          <div className="link-preview-meta">
+            {favicon && <img src={favicon} alt="" referrerPolicy="no-referrer" />}
+            <span>{site_name || domain}</span>
+          </div>
+        </div>
+      </a>
+    </div>
+  );
+};
+
+export default LinkPreview;

--- a/src/styles/LinkPreview.css
+++ b/src/styles/LinkPreview.css
@@ -1,0 +1,150 @@
+/* ─── LinkPreview Component ─── */
+
+.link-preview-card {
+  display: flex;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 8px;
+  background: #fff;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  max-width: 520px;
+}
+
+.link-preview-card:hover {
+  border-color: #3b82f6;
+  box-shadow: 0 1px 4px rgba(59, 130, 246, 0.15);
+}
+
+.link-preview-card a {
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  width: 100%;
+}
+
+/* ─── Thumbnail ─── */
+.link-preview-thumb {
+  width: 120px;
+  min-width: 120px;
+  min-height: 68px;
+  background: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.link-preview-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.link-preview-favicon-only {
+  width: 32px;
+  height: 32px;
+  opacity: 0.6;
+}
+
+/* ─── Content ─── */
+.link-preview-content {
+  padding: 10px 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.link-preview-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1f2937;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+
+.link-preview-desc {
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+
+.link-preview-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: #9ca3af;
+}
+
+.link-preview-meta img {
+  width: 14px;
+  height: 14px;
+}
+
+/* ─── Skeleton Loading ─── */
+@keyframes link-preview-shimmer {
+  0% { background-position: -200px 0; }
+  100% { background-position: calc(200px + 100%) 0; }
+}
+
+.link-preview-skeleton {
+  display: flex;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 8px;
+  max-width: 520px;
+  height: 80px;
+}
+
+.link-preview-skeleton .sk-thumb {
+  width: 120px;
+  min-width: 120px;
+  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background-size: 200px 100%;
+  animation: link-preview-shimmer 1.5s infinite;
+}
+
+.link-preview-skeleton .sk-content {
+  flex: 1;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.link-preview-skeleton .sk-line {
+  height: 12px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background-size: 200px 100%;
+  animation: link-preview-shimmer 1.5s infinite;
+}
+
+.link-preview-skeleton .sk-line:first-child {
+  width: 90%;
+}
+
+.link-preview-skeleton .sk-line:last-child {
+  width: 65%;
+}
+
+/* ─── Error fallback ─── */
+.link-preview-error {
+  margin-top: 8px;
+}
+
+.link-preview-error a {
+  color: #3b82f6;
+  font-size: 13px;
+  word-break: break-all;
+}


### PR DESCRIPTION
## 🔗 LinkPreview — Componente Frontend

### ¿Qué hace?
Detecta URLs en mensajes/tareas y muestra una tarjeta de previsualización con metadata extraída por el backend (Obscura).

### Archivos nuevos
- **`src/api/previewApi.js`** — `fetchLinkPreview(url)` + `extractFirstUrl(text)`
- **`src/components/LinkPreview.jsx`** — Componente React con 3 estados
  - Loading: skeleton animado con shimmer effect
  - Loaded: tarjeta horizontal con thumbnail + título + descripción + favicon
  - Error: fallback elegante (solo link)
- **`src/styles/LinkPreview.css`** — Estilos completos con animaciones

### Archivos modificados
- **`src/components/CreateMessage.jsx`** — Detección de URLs con debounce 600ms, preview bajo el textarea
- **`src/components/EditMessages.jsx`** — Misma integración

### Cómo probar
1. Abrir "/crear-mensaje"
2. Pegar una URL en el campo mensaje (ej: https://blog.rust-lang.org)
3. Esperar ~1s → aparece tarjeta de preview debajo del textarea
4. La tarjeta muestra: thumbnail, título, descripción, favicon

### Requiere
- PR backend: https://github.com/sti-chile/docktask_backend/pull/15

---
⚡ Zion — STI Chile