### PR TITLE
🔒 Fix: localStorage → prop token injection (crear mensaje/proyecto roto)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,8 @@ function App() {
 // Wrapper para extraer :id de la URL y pasarlo como prop a GanttBoard
 function GanttWrapper() {
   const { id } = useParams();
-  return <GanttBoard proyectoId={id} />;
+  const { token } = useAuth();
+  return <GanttBoard proyectoId={id} token={token} />;
 }
 
 export default App;

--- a/src/api/previewApi.js
+++ b/src/api/previewApi.js
@@ -3,9 +3,9 @@
  * Llama al endpoint de Obscura para extraer metadata de URLs.
  */
 
-export async function fetchLinkPreview(url) {
-  const token = localStorage.getItem('access_token');
-  const res = await fetch('/api/v1/preview/link', {
+export async function fetchLinkPreview(url, token) {
+  const API_BASE = import.meta.env.VITE_API_URL || 'https://api.docktask.com';
+  const res = await fetch(`${API_BASE}/api/v1/preview/link`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/components/CreateMessage.jsx
+++ b/src/components/CreateMessage.jsx
@@ -127,7 +127,7 @@ const CreateMessage = ({ token }) => {
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="Ingrese el contenido del mensaje (puede incluir enlaces)"
               />
-              {previewUrl && <LinkPreview url={previewUrl} />}
+              {previewUrl && <LinkPreview url={previewUrl} token={token} />}
             </div>
 
             {!projectId && (

--- a/src/components/CreateProject.jsx
+++ b/src/components/CreateProject.jsx
@@ -25,9 +25,8 @@ const CreateProject = ({ token }) => {
     setLoading(true);
 
     try {
-      const token = localStorage.getItem('token');
       const user = jwtDecode(token);
-      const owner_id = user.id;
+      const owner_id = user.sub;
       const formDataOwner = {
         ...formData,
         owner_id,

--- a/src/components/GanttBoard.jsx
+++ b/src/components/GanttBoard.jsx
@@ -5,12 +5,36 @@ import "gantt-task-react/dist/index.css";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { createHttpClient } from "@/lib/httpClient";
 
-const GanttBoard = ({ proyectoId }) => {
+const GanttBoard = ({ proyectoId, mensajes: propsMensajes, token }) => {
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    // Modo embedido: recibe mensajes directamente
+    if (propsMensajes) {
+      const tareasValidas = propsMensajes
+        .filter((m) => m.start_date && m.expiration_date)
+        .map((m) => ({
+          id: String(m.id),
+          name: m.nombre,
+          start: new Date(m.start_date),
+          end: new Date(m.expiration_date),
+          type: "task",
+          progress: m.estado === "completado" ? 100 : m.estado === "en_progreso" ? 50 : 0,
+          isDisabled: false,
+          dependencies: [],
+        }));
+      if (tareasValidas.length === 0) {
+        setError("No hay mensajes con fechas asignadas para mostrar en el Gantt.");
+      } else {
+        setTasks(tareasValidas);
+      }
+      setLoading(false);
+      return;
+    }
+
+    // Modo standalone: carga mensajes del proyecto
     if (!proyectoId) {
       setError("No se especificó un proyecto.");
       setLoading(false);
@@ -18,7 +42,6 @@ const GanttBoard = ({ proyectoId }) => {
     }
 
     const controller = new AbortController();
-    const token = localStorage.getItem("token");
     const api = createHttpClient(token);
 
     api
@@ -53,7 +76,7 @@ const GanttBoard = ({ proyectoId }) => {
       });
 
     return () => controller.abort();
-  }, [proyectoId]);
+  }, [proyectoId, propsMensajes]);
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/src/components/LinkPreview.jsx
+++ b/src/components/LinkPreview.jsx
@@ -8,7 +8,7 @@ import '../styles/LinkPreview.css';
  * 
  * @param {{ url: string }} props
  */
-const LinkPreview = ({ url }) => {
+const LinkPreview = ({ url, token }) => {
   const [state, setState] = useState('loading'); // loading | loaded | error
   const [data, setData] = useState(null);
 
@@ -19,7 +19,7 @@ const LinkPreview = ({ url }) => {
     setState('loading');
     setData(null);
 
-    fetchLinkPreview(url)
+    fetchLinkPreview(url, token)
       .then((result) => {
         if (!cancelled) {
           setData(result);

--- a/src/components/containers/MessagesContainer.jsx
+++ b/src/components/containers/MessagesContainer.jsx
@@ -110,10 +110,7 @@ const MessagesContainer = ({ token }) => {
       {activeView === 'gantt' && (
         <GanttBoard
           mensajes={mensajes}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-          onEstadoChange={handleEstadoChange}
-          onFechaExpiracionChange={handleFechaExpiracionChange}
+          token={token}
         />
       )}
     </div>


### PR DESCRIPTION
## Bug
El sistema de auth seguro eliminó localStorage, pero varios componentes seguían leyendo el token de allí → `jwtDecode(null)` → error silencioso → no permite crear mensajes ni proyectos.

## Fixes
- **CreateProject.jsx**: usa prop `token` en vez de `localStorage.getItem("token")`
- **GanttBoard.jsx**: acepta token via prop, soporta modo embebido (mensajes directos) y modo standalone (fetch via API)
- **previewApi.js `fetchLinkPreview`**: recibe token como parámetro, usa URL absoluta con `VITE_API_URL`
- **LinkPreview.jsx**: recibe y propaga token a fetchLinkPreview
- **CreateMessage.jsx**: pasa token a LinkPreview
- **MessagesContainer.jsx**: pasa token a GanttBoard
- **App.jsx `GanttWrapper`**: obtiene token de useAuth y lo pasa a GanttBoard

## Archivos
7 archivos, +36/-16 líneas