### PR TITLE
fix(sockets): elimina token del query string en conexión SocketIO [F0…

### DIFF
--- a/src/context/NotificationContext.jsx
+++ b/src/context/NotificationContext.jsx
@@ -37,7 +37,6 @@ export const NotificationProvider = ({ children }) => {
 
     const socket = io(API_URL, {
       auth: { token },
-      query: { token },
       transports: ['websocket', 'polling'],
       reconnection: true,
       reconnectionAttempts: 5,


### PR DESCRIPTION
….T3]

- Elimina query: { token } de la conexión io()
- El token ya se envía via auth: { token }, que va en el handshake y no queda expuesto en logs del servidor

Refs: F0.T3 en Notion DB Tareas DockTask