### PR TITLE
fix: resolver conflictos de merge en capabilities/default.json

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,6 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "DockTask — permisos desktop (Linux, Windows, macOS)",
-<<<<<<< HEAD
   "platforms": ["linux", "windows", "macOS"],
   "windows": ["main"],
   "permissions": [
@@ -26,7 +25,6 @@
     "os:default",
     "os:allow-platform",
     "deep-link:default",
-<<<<<<< HEAD
     "deep-link:allow-get-current",
     "updater:default",
     "updater:allow-check",


### PR DESCRIPTION
Los conflictos <<<<<<< HEAD anidados dejaban el JSON invalido, causando error 'key must be a string at line 5 column 1' al compilar Tauri. Se mantiene la version con updater + deep-link.